### PR TITLE
Fix: Corrected Handling of Observed Elements on GitHub Pages

### DIFF
--- a/Extension Files/assets/js/getGithubDevProfileCoordinate.js
+++ b/Extension Files/assets/js/getGithubDevProfileCoordinate.js
@@ -22,81 +22,83 @@ console.log('Developer Profile Script Started');
 
 // listens for data from different GitHub profile attributes then sends a response based on its results
 chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
-    const elements = document.elementsFromPoint(msg.x, msg.y);
-    let sentResult = false;
-    for (element of elements) {
-        if (element.classList.contains("avatar") && element.tagName === 'IMG') {
-            console.log('avatar image'); 
-            sentResult = true;
-            sendResponse({ result: `AvatarImage-`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return;
+    if (msg.text == 'get_github_dev_profile_coordinate'){
+        const elements = document.elementsFromPoint(msg.x, msg.y);
+        let sentResult = false;
+        for (element of elements) {
+            if (element.classList.contains("avatar") && element.tagName === 'IMG') {
+                console.log('avatar image'); 
+                sentResult = true;
+                sendResponse({ result: `AvatarImage-`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                return;
+            }
+            if (element.classList.contains("js-activity-overview-graph-container") && element.attributes.getNamedItem('data-percentages')) {
+                console.log("activity overview");
+                let activityOverview = element.attributes.getNamedItem('data-percentages').value;
+                activityOverview = JSON.parse(activityOverview);
+                const percentCommits = activityOverview["Commits"];
+                const percentCodeReview = activityOverview["Code review"];
+                const percentPullRequests = activityOverview["Pull requests"];
+                sentResult = true;
+                sendResponse({ result: `ActivityOverview-Commit:${percentCommits}%,CodeReview:${percentCodeReview}%,PullRequest:${percentPullRequests}%`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                return; 
+            }
+            if (element.tagName === 'DIV' && element.classList.contains("graph-before-activity-overview")) {
+                console.log('contribution heat map')
+                sentResult = true;
+                sendResponse({ result: `ContributionHeatMap`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                return; 
+            }
+            if (element.id.includes("year-link")) {
+                console.log('Year Link')
+                const year = element.id;
+                sentResult = true;
+                sendResponse({ result: `Year-${year}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                return; 
+            }
+            if (element.tagName === 'SPAN' && element.classList.contains("label")) {
+                console.log('profile label')
+                const labelName = element.innerHTML;
+                sentResult = true;
+                sendResponse({ result: `ProfileLabel-${labelName}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                return; 
+            }
+            if (element.tagName === 'A' && element.attributes.getNamedItem("data-hovercard-type") && element.attributes.getNamedItem("data-hovercard-type").value === "organization"
+                && element.classList.contains("avatar-group-item")) {
+                console.log('Organization')
+                console.log(element);
+                const organizationName = element.attributes.getNamedItem("aria-label").value;
+                sentResult = true;
+                sendResponse({ result: `Organization-${organizationName}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                return; 
+            }
+            if (element.tagName === 'A' && element.attributes.getNamedItem("itemprop") && element.attributes.getNamedItem("itemprop").value.includes("codeRepository")) {
+                console.log('Contributed repositories')
+                const repoName = element.innerHTML;
+                sentResult = true;
+                sendResponse({ result: `Repository-${repoName}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                return; 
+            }
+            if (element.classList.contains("Counter")) {
+                console.log("tab Counter")
+                const tab = element.parentElement.innerHTML; 
+                const number = element.innerHTML
+                sentResult = true;
+                sendResponse({ result: `Num${tab}-${number}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                return;
+            }
+            if (element.classList.contains("Profile-rollup-wrapper")) {
+                console.log("Contribution Acitivty Entry")
+                // Need more info on the contribution 
+                sentResult = true;
+                sendResponse({ result: `ContributionActivity-`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                return;
+            }
         }
-        if (element.classList.contains("js-activity-overview-graph-container") && element.attributes.getNamedItem('data-percentages')) {
-            console.log("activity overview");
-            let activityOverview = element.attributes.getNamedItem('data-percentages').value;
-            activityOverview = JSON.parse(activityOverview);
-            const percentCommits = activityOverview["Commits"];
-            const percentCodeReview = activityOverview["Code review"];
-            const percentPullRequests = activityOverview["Pull requests"];
-            sentResult = true;
-            sendResponse({ result: `ActivityOverview-Commit:${percentCommits}%,CodeReview:${percentCodeReview}%,PullRequest:${percentPullRequests}%`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return; 
+        if (!sentResult) {
+            sendResponse(null);
         }
-        if (element.tagName === 'DIV' && element.classList.contains("graph-before-activity-overview")) {
-            console.log('contribution heat map')
-            sentResult = true;
-            sendResponse({ result: `ContributionHeatMap`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return; 
-        }
-        if (element.id.includes("year-link")) {
-            console.log('Year Link')
-            const year = element.id;
-            sentResult = true;
-            sendResponse({ result: `Year-${year}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return; 
-        }
-        if (element.tagName === 'SPAN' && element.classList.contains("label")) {
-            console.log('profile label')
-            const labelName = element.innerHTML;
-            sentResult = true;
-            sendResponse({ result: `ProfileLabel-${labelName}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return; 
-        }
-        if (element.tagName === 'A' && element.attributes.getNamedItem("data-hovercard-type") && element.attributes.getNamedItem("data-hovercard-type").value === "organization"
-            && element.classList.contains("avatar-group-item")) {
-            console.log('Organization')
-            console.log(element);
-            const organizationName = element.attributes.getNamedItem("aria-label").value;
-            sentResult = true;
-            sendResponse({ result: `Organization-${organizationName}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return; 
-        }
-        if (element.tagName === 'A' && element.attributes.getNamedItem("itemprop") && element.attributes.getNamedItem("itemprop").value.includes("codeRepository")) {
-            console.log('Contributed repositories')
-            const repoName = element.innerHTML;
-            sentResult = true;
-            sendResponse({ result: `Repository-${repoName}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return; 
-        }
-        if (element.classList.contains("Counter")) {
-            console.log("tab Counter")
-            const tab = element.parentElement.innerHTML; 
-            const number = element.innerHTML
-            sentResult = true;
-            sendResponse({ result: `Num${tab}-${number}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return;
-        }
-        if (element.classList.contains("Profile-rollup-wrapper")) {
-            console.log("Contribution Acitivty Entry")
-            // Need more info on the contribution 
-            sentResult = true;
-            sendResponse({ result: `ContributionActivity-`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return;
-        }
-    }
-    if (!sentResult) {
-        sendResponse(null);
-    }
 
-    // Still need to check: Profile label, URL pattern matching, contribution activity entry, organizations, counters
+        // Still need to check: Profile label, URL pattern matching, contribution activity entry, organizations, counters
+    }
 });

--- a/Extension Files/assets/js/getGithubIssueListCoordinate.js
+++ b/Extension Files/assets/js/getGithubIssueListCoordinate.js
@@ -18,106 +18,106 @@
  ************************************************************************************************************************
  ********************************/
 
-console.log('Github Issuees Script Started');
-
+console.log('Github Issues Script Started');
 // listens for the different GitHub issue coordinates and data associated with it, then sends
 // response based on its results
 chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
-    const elements = document.elementsFromPoint(msg.x, msg.y);
-    let sentResult = false;
-    for (element of elements) {
-        console.log("looping");
-        if (element.classList.contains('btn-link') && element.innerHTML.includes('Open') && element.tagName === 'A') {
-            console.log("Number of issues open");
-            const numberOpen = element.innerHTML;
-            sentResult = true;
-            sendResponse({ result: `NumIssuesOpen-${numberOpen}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return;
-        }
-        if (element.classList.contains('social-count') && element.tagName === 'A') {
-            const ariaLabel = element.attributes.getNamedItem('aria-label').value;
-            if (ariaLabel.includes('forked')) {
-                console.log('Number of users who have forked repository');
-                const numberForked = element.innerHTML;
+    if (msg.text == 'get_github_issues_coordinate'){
+        const elements = document.elementsFromPoint(msg.x, msg.y);
+        let sentResult = false;
+        for (element of elements) {
+            if (element.classList.contains('btn-link') && element.innerHTML.includes('Open') && element.tagName === 'A') {
+                console.log("Number of issues open");
+                const numberOpen = element.innerHTML;
                 sentResult = true;
-                sendResponse({ result: `NumOfForked-${numberForked}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                sendResponse({ result: `NumIssuesOpen-${numberOpen}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
                 return;
-
-            } else if (ariaLabel.includes('watching')) {
-                console.log('Number of users who are watching repository');
-                const numberWatching = element.innerHTML;
+            }
+            if (element.classList.contains('social-count') && element.tagName === 'A') {
+                const ariaLabel = element.attributes.getNamedItem('aria-label').value;
+                if (ariaLabel.includes('forked')) {
+                    console.log('Number of users who have forked repository');
+                    const numberForked = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({ result: `NumOfForked-${numberForked}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                    return;
+    
+                } else if (ariaLabel.includes('watching')) {
+                    console.log('Number of users who are watching repository');
+                    const numberWatching = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({ result: `NumOfWatching- ${numberWatching}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                    return;
+                } else if (ariaLabel.includes('starred')) {
+                    console.log('Number of users who starred repository');
+                    const numberStarred= element.innerHTML;
+                    sentResult = true;
+                    sendResponse({ result: `NumOfStarred-${numberStarred}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                    return;
+                }
+            }
+            if (element.classList.contains('url') && element.classList.contains('fn') && element.tagName === 'A') {
+                if (!element.attributes.getNamedItem('data-hovercard-type')) {
+                    return;
+                } 
+                if (element.attributes.getNamedItem('data-hovercard-type') === 'organization') {
+                    console.log("Project/Organization Name");
+                    const organization = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({ result: `ProjectName-${organization}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                    return;
+                }
+            }
+            if (element.classList.contains('IssueLabel')) {
+                console.log('Issue label')
+                const labelTitle = element.textContent;
                 sentResult = true;
-                sendResponse({ result: `NumOfWatching- ${numberWatching}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                sendResponse({ result: `IssueLabel-${labelTitle}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
                 return;
-            } else if (ariaLabel.includes('starred')) {
-                console.log('Number of users who starred repository');
-                const numberStarred= element.innerHTML;
+            }
+            if (element.classList.contains('muted-link')) {
+                if (!element.attributes.getNamedItem('data-hovercard-type')) {
+                    return;
+                }
+                const linkType = element.attributes.getNamedItem('data-hovercard-type').value 
+                if (linkType === 'user') {
+                    console.log('user link')
+                    const user = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({ result: `Username-${user}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                    return;
+                } else if (linkType === 'issue') {
+                    console.log('issue link')
+                    const issue = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({ result: `Issue-${issue}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                    return;
+                } else if (linkType.includes
+                    ("comments")) {
+                    const numberOfComments = element.attributes.getNamedItem('aria-label').value;
+                    sentResult = true;
+                    sendResponse({ result: `NumOfComments-${numberOfComments}`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
+                    return;
+                }
+            }
+            if (element.tagName === 'RELATIVE-TIME') {
+                console.log('Time open')
+                const opened = element.innerHTML;
+                const timestamp = element.attributes.getNamedItem('title').value;
                 sentResult = true;
-                sendResponse({ result: `NumOfStarred-${numberStarred}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                sendResponse({ result: `IssueOpened-${opened} on ${timestamp}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                return;
+            }
+            if (element.classList.contains('task-progress-counts')) {
+                console.log('Task progress bar')
+                const taskProgress = element.innerHTML;
+                sentResult = true;
+                sendResponse({ result: `TaskCompletion-${taskProgress}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
                 return;
             }
         }
-        if (element.classList.contains('url') && element.classList.contains('fn') && element.tagName === 'A') {
-            if (!element.attributes.getNamedItem('data-hovercard-type')) {
-                return;
-            } 
-            if (element.attributes.getNamedItem('data-hovercard-type') === 'organization') {
-                console.log("Project/Organization Name");
-                const organization = element.innerHTML;
-                sentResult = true;
-                sendResponse({ result: `ProjectName-${organization}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-                return;
-            }
+        if (!sentResult) {
+            sendResponse(null);
         }
-        if (element.classList.contains('IssueLabel')) {
-            console.log('Issue label')
-            const labelTitle = element.innerHTML;
-            sentResult = true;
-            sendResponse({ result: `IssueLabel-${labelTitle}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return;
-        }
-        if (element.classList.contains('muted-link')) {
-            if (!element.attributes.getNamedItem('data-hovercard-type')) {
-                return;
-            }
-            const linkType = element.attributes.getNamedItem('data-hovercard-type').value 
-            if (linkType === 'user') {
-                console.log('user link')
-                const user = element.innerHTML;
-                sentResult = true;
-                sendResponse({ result: `Username-${user}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-                return;
-            } else if (linkType === 'issue') {
-                console.log('issue link')
-                const issue = element.innerHTML;
-                sentResult = true;
-                sendResponse({ result: `Issue-${issue}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-                return;
-            } else if (linkType.includes
-                ("comments")) {
-                const numberOfComments = element.attributes.getNamedItem('aria-label').value;
-                sentResult = true;
-                sendResponse({ result: `NumOfComments-${numberOfComments}`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
-                return;
-            }
-        }
-        if (element.tagName === 'RELATIVE-TIME') {
-            console.log('Time open')
-            const opened = element.innerHTML;
-            const timestamp = element.attributes.getNamedItem('title').value;
-            sentResult = true;
-            sendResponse({ result: `IssueOpened-${opened} on ${timestamp}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return;
-        }
-        if (element.classList.contains('task-progress-counts')) {
-            console.log('Task progress bar')
-            const taskProgress = element.innerHTML;
-            sentResult = true;
-            sendResponse({ result: `TaskCompletion-${taskProgress}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return;
-        }
-    }
-    if (!sentResult) {
-        sendResponse(null);
     }
 });

--- a/Extension Files/assets/js/getGithubPRListCoordinate.js
+++ b/Extension Files/assets/js/getGithubPRListCoordinate.js
@@ -22,123 +22,125 @@ console.log('Github Pull Requests Script Started');
 
 // looks at a specific pull request and listen/logs the data and things associated with pull requests
 chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
-    const elements = document.elementsFromPoint(msg.x, msg.y);
-    let sentResult = false;
-    for (element of elements) {
-        if(element.tagName === 'A' && element.classList.contains('text-red')) {
-          console.log("Travis CI Failure")
-          sentResult = true;
-          sendResponse({ result: `CITests-Failing`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
-          return;
-        }
-        if(element.tagName === 'A' && element.classList.contains('text-green')) {
-            console.log("Travis CI Passing")
+    if (msg.text == 'get_github_prlist_coordinate'){
+        const elements = document.elementsFromPoint(msg.x, msg.y);
+        let sentResult = false;
+        for (element of elements) {
+            if(element.tagName === 'A' && element.classList.contains('text-red')) {
+            console.log("Travis CI Failure")
             sentResult = true;
-            sendResponse({ result: `CITests-Passing`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
+            sendResponse({ result: `CITests-Failing`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
             return;
-        }
-        if (element.classList.contains('btn-link') && element.innerHTML.includes('Open') && element.tagName === 'A') {
-            console.log("Number of PRs open");
-            const numberOpen = element.innerHTML;
-            sentResult = true;
-            sendResponse({ result: `NumPROpen-${numberOpen}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return;
-        }
-        if (element.classList.contains('url') && element.classList.contains('fn') && element.tagName === 'A') {
-            if (!element.attributes.getNamedItem('data-hovercard-type')) {
-                return;
-            } 
-            if (element.attributes.getNamedItem('data-hovercard-type') === 'organization') {
-                console.log("Project/Organization Name");
-                const organization = element.innerHTML;
+            }
+            if(element.tagName === 'A' && element.classList.contains('text-green')) {
+                console.log("Travis CI Passing")
                 sentResult = true;
-                sendResponse({ result: `ProjectName - ${organization}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                sendResponse({ result: `CITests-Passing`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
+                return;
+            }
+            if (element.classList.contains('btn-link') && element.innerHTML.includes('Open') && element.tagName === 'A') {
+                console.log("Number of PRs open");
+                const numberOpen = element.innerHTML;
+                sentResult = true;
+                sendResponse({ result: `NumPROpen-${numberOpen}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                return;
+            }
+            if (element.classList.contains('url') && element.classList.contains('fn') && element.tagName === 'A') {
+                if (!element.attributes.getNamedItem('data-hovercard-type')) {
+                    return;
+                } 
+                if (element.attributes.getNamedItem('data-hovercard-type') === 'organization') {
+                    console.log("Project/Organization Name");
+                    const organization = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({ result: `ProjectName - ${organization}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                    return;
+                }
+            }
+            if (element.classList.contains('social-count') && element.tagName === 'A') {
+                const ariaLabel = element.attributes.getNamedItem('aria-label').value;
+                if (ariaLabel.includes('forked')) {
+                    console.log('Number of users who have forked repository');
+                    const numberForked = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({ result: `NumOfForked-${numberForked}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                    return;
+                } else if (ariaLabel.includes('watching')) {
+                    console.log('Number of users who are watching repository');
+                    const numberWatching = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({ result: `NumOfWatching-${numberWatching}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                    return;
+                } else if (ariaLabel.includes('starred')) {
+                    console.log('Number of users who starred repository');
+                    const numberStarred= element.innerHTML;
+                    sentResult = true;
+                    sendResponse({ result: `NumOfStarred-${numberStarred}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                    return;
+                }
+            }
+            if (element.tagName === 'A' && element.attributes.getNamedItem("aria-label") && element.attributes.getNamedItem("aria-label").value.includes("comments")) {
+                console.log('Number of comments')
+                const numberOfComments = element.attributes.getNamedItem('aria-label').value;
+                sentResult = true;
+                sendResponse({ result: `NumOfComments-${numberOfComments}`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
+                return;
+            }
+            if (element.classList.contains('muted-link') && element.attributes.getNamedItem('data-hovercard-type')) {
+                const linkType = element.attributes.getNamedItem('data-hovercard-type').value;
+                if (linkType === 'user') {
+                    console.log('User')
+                    const user = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({ result: `Username-${user}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                    return;
+                } else if (linkType === 'pull_requires') {
+                    console.log('Pull request')
+                    const pullRequest = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({ result: `PullRequest-${pullRequest}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                    return;
+                } else if (linkType.includes("review approval")) {
+                    console.log('# of approvals')
+                    const numApprovals = element.attributes.getNamedItem('aria-label').value;
+                    sentResult = true;
+                    sendResponse({ result: `NumApprovals-${numApprovals}`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
+                    return;
+                }
+            }
+            if (element.classList.contains('muted-link') && element.attributes.getNamedItem('aria-label')) {
+                const label = element.attributes.getNamedItem('aria-label').value;
+                if (label.includes('approval')) {
+                    console.log('Approval')
+                    sentResult = true;
+                    sendResponse({ result: `PRStatus-Approval`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
+                    return;
+                } else if (label.includes('requesting changes')) {
+                    console.log('Changes requested')
+                    sentResult = true;
+                    sendResponse({ result: `PRStatus-Changes Requested`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
+                    return;
+                }
+            }
+            if (element.tagName === 'RELATIVE-TIME') {
+                console.log('Time opened')
+                const opened = element.innerHTML;
+                const timestamp = element.attributes.getNamedItem('title').value;
+                sentResult = true;
+                sendResponse({ result: `PullRequestOpened-${opened} on ${timestamp}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+                return;
+            }
+            if (element.classList.contains('task-progress-counts')) {
+                console.log('Task progress count')
+                const taskProgress = element.innerHTML;
+                sentResult = true;
+                sendResponse({ result: `TaskCompletion-${taskProgress}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
                 return;
             }
         }
-        if (element.classList.contains('social-count') && element.tagName === 'A') {
-            const ariaLabel = element.attributes.getNamedItem('aria-label').value;
-            if (ariaLabel.includes('forked')) {
-                console.log('Number of users who have forked repository');
-                const numberForked = element.innerHTML;
-                sentResult = true;
-                sendResponse({ result: `NumOfForked-${numberForked}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-                return;
-            } else if (ariaLabel.includes('watching')) {
-                console.log('Number of users who are watching repository');
-                const numberWatching = element.innerHTML;
-                sentResult = true;
-                sendResponse({ result: `NumOfWatching-${numberWatching}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-                return;
-            } else if (ariaLabel.includes('starred')) {
-                console.log('Number of users who starred repository');
-                const numberStarred= element.innerHTML;
-                sentResult = true;
-                sendResponse({ result: `NumOfStarred-${numberStarred}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-                return;
-            }
+        if (!sentResult) {
+            sendResponse(null);
         }
-        if (element.tagName === 'A' && element.attributes.getNamedItem("aria-label") && element.attributes.getNamedItem("aria-label").value.includes("comments")) {
-            console.log('Number of comments')
-            const numberOfComments = element.attributes.getNamedItem('aria-label').value;
-            sentResult = true;
-            sendResponse({ result: `NumOfComments-${numberOfComments}`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
-            return;
-        }
-        if (element.classList.contains('muted-link') && element.attributes.getNamedItem('data-hovercard-type')) {
-            const linkType = element.attributes.getNamedItem('data-hovercard-type').value;
-            if (linkType === 'user') {
-                console.log('User')
-                const user = element.innerHTML;
-                sentResult = true;
-                sendResponse({ result: `Username-${user}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-                return;
-            } else if (linkType === 'pull_requires') {
-                console.log('Pull request')
-                const pullRequest = element.innerHTML;
-                sentResult = true;
-                sendResponse({ result: `PullRequest-${pullRequest}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-                return;
-            } else if (linkType.includes("review approval")) {
-                console.log('# of approvals')
-                const numApprovals = element.attributes.getNamedItem('aria-label').value;
-                sentResult = true;
-                sendResponse({ result: `NumApprovals-${numApprovals}`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
-                return;
-            }
-        }
-        if (element.classList.contains('muted-link') && element.attributes.getNamedItem('aria-label')) {
-            const label = element.attributes.getNamedItem('aria-label').value;
-            if (label.includes('approval')) {
-                console.log('Approval')
-                sentResult = true;
-                sendResponse({ result: `PRStatus-Approval`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
-                return;
-            } else if (label.includes('requesting changes')) {
-                console.log('Changes requested')
-                sentResult = true;
-                sendResponse({ result: `PRStatus-Changes Requested`, x: msg.x, y: msg.y, time: msg.time, url: msg.url });
-                return;
-            }
-        }
-        if (element.tagName === 'RELATIVE-TIME') {
-            console.log('Time opened')
-            const opened = element.innerHTML;
-            const timestamp = element.attributes.getNamedItem('title').value;
-            sentResult = true;
-            sendResponse({ result: `PullRequestOpened-${opened} on ${timestamp}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return;
-        }
-        if (element.classList.contains('task-progress-counts')) {
-            console.log('Task progress count')
-            const taskProgress = element.innerHTML;
-            sentResult = true;
-            sendResponse({ result: `TaskCompletion-${taskProgress}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-            return;
-        }
-    }
-    if (!sentResult) {
-        sendResponse(null);
     }
 });
 

--- a/Extension Files/assets/js/getGithubPullRequestCoordinate.js
+++ b/Extension Files/assets/js/getGithubPullRequestCoordinate.js
@@ -22,6 +22,7 @@ console.log('Github List of Pull Requests Script Started');
 
 // looks at list of pull requests and logs its data
 chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
+  if (msg.text == 'get_github_pr_coordinate'){
     const elements = document.elementsFromPoint(msg.x, msg.y);
     let sentResult = false;
     for (element of elements) {
@@ -45,41 +46,33 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         sendResponse({ result: `ChecklistItem-`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
         return;
       }
-      // if (element.tagName === 'A' && element.classList.contains('participant-avatar')) {
-      //   console.log("participant")
-      //   sentResult = true;
-      //   const user = element.attributes.getNamedItem('data-hovercard-url').value.split('/')[2];
-      //   console.log(user);
-      //   sendResponse({ result: `Participant-${user}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
-      //   return; 
-      // }
 
       // Number of files changed
       if (element.id === 'files_tab_counter') {
         console.log('# of files changed');
         sentResult = true;
-        sendResponse({ result: `NumOfFilesChanged-${element.innerHTML.trim()}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+        sendResponse({ result: `NumOfFilesChanged-${element.textContent.trim()}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
         return;
       }
       // Number of checks
       if (element.id === 'checks_tab_counter') {
         console.log('# Checks');
         sentResult = true;
-        sendResponse({ result: `NumOfChecks-${element.innerHTML.trim()}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+        sendResponse({ result: `NumOfChecks-${element.textContent.trim()}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
         return;
       }
       // Number of commits
       if (element.id === 'commits_tab_counter') {
         console.log('# Commits');
         sentResult = true;
-        sendResponse({ result: `NumOfCommits-${element.innerHTML.trim()}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+        sendResponse({ result: `NumOfCommits-${element.textContent.trim()}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
         return;
       }
       // Number of conversations
       if (element.id === 'conversation_tab_counter') {
         console.log('# Conversations');
         sentResult = true;
-        sendResponse({ result: `NumOfConversationComments-${element.innerHTML.trim()}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+        sendResponse({ result: `NumOfConversationComments-${element.textContent.trim()}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
         return;
       }
       // Number of total diffs
@@ -103,31 +96,27 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
       if (element.tagName === 'TD' && element.classList.contains('blob-code-deletion')) {
         console.log('Deleted Line of Code');
         let lineNumber = 0;
-        if (element.attributes.getNamedItem('data-line-number')) {
-          lineNumber = element.attributes.getNamedItem('data-line-number').value;
-        }  
+        lineNumber = element.previousElementSibling.attributes.getNamedItem('data-line-number').value;  
         sentResult = true;
-        sendResponse({ result: `DeletedLOC-${lineNumber}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
+        sendResponse({ result: `DeletedLOC-${lineNumber}`, x: msg.x, y: msg.y, time: msg.time, id:element.id, url: msg.url });
         return;
       }
+
       // Added line of code
       if (element.tagName === 'TD' && element.classList.contains('blob-code-addition')) {
         console.log('Added Line of Code');
         let lineNumber = 0;
-        if (element.attributes.getNamedItem('data-line-number')) {
-          lineNumber = element.attributes.getNamedItem('data-line-number').value;
-        }
+        lineNumber = element.previousElementSibling.attributes.getNamedItem('data-line-number').value;
         sentResult = true;
         sendResponse({ result: `AddedLOC-${lineNumber}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
         return;
       }
+
       // Unchanged line of code
       if (element.tagName === 'TD' && element.classList.contains('blob-code-context')) {
         console.log('Unchanged Line of Code');
         let lineNumber = 0;
-        if (element.attributes.getNamedItem('data-line-number')) {
-          lineNumber = element.attributes.getNamedItem('data-line-number').value;
-        } 
+        lineNumber = element.previousElementSibling.attributes.getNamedItem('data-line-number').value; 
         sendResponse({ result: `UnchangedLOC-${lineNumber}`, x: msg.x, y: msg.y, time: msg.time, id: element.id, url: msg.url });
         return;
       }
@@ -270,4 +259,5 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
     if (!sentResult) {
         sendResponse(null);
     }
+  }
 });

--- a/Extension Files/manifest.json
+++ b/Extension Files/manifest.json
@@ -6,40 +6,8 @@
   "version": "0.0.1",
   "content_scripts": [
     {
-      "matches": ["*://stackoverflow.com/questions/*"],
-      "js": ["/assets/js/getSOCoordinate.js"]
-    },
-    {
-      "matches": ["*://bugs.eclipse.org/*", "*://bugzilla.mozilla.org/*", "*://bugzilla.kernel.org/*", "*://bz.apache.org/*"],
-      "js": ["/assets/js/getBZCoordinate.js"]
-    },
-    {
-      "matches": ["https://stackoverflow.com/*"],
-      "js": ["/assets/js/getSearchCoordinate.js"]
-    },
-    {
-      "matches": ["https://*.google.com/*"],
-      "js": ["/assets/js/getGoogleCoordinate.js"]
-    },
-    {
-      "matches": ["https://github.com/*/*/issues"],
-      "js": ["/assets/js/getGithubIssueListCoordinate.js"]
-    },
-    {
-      "matches": ["https://github.com/*/*/pulls"],
-      "js": ["/assets/js/getGithubPRListCoordinate.js"]
-    },
-    {
-      "matches": ["https://github.com/*/pull/*"],
-      "js": ["/assets/js/getGithubPullRequestCoordinate.js"]
-    },
-    {
-      "matches": ["https://github.com/*/"],
-      "js": ["/assets/js/getGithubDevProfileCoordinate.js"]
-    },
-    {
-      "matches": ["https://github.com/*tab*"],
-      "js": ["/assets/js/getGithubDevProfileCoordinate.js"]
+      "matches": ["*://github.com/*"],
+      "js": ["/assets/js/loader.js"]
     }
   ],
   "background": {
@@ -58,8 +26,5 @@
 	  "tabs",
     "activeTab",
     "downloads"
-  ],
-  "externally_connectable": {
-    "matches": ["*://*.stackoverflow.com/**", "https://stackoverflow.com/*"]
-  }
+  ]
 }

--- a/Extension Files/manifestv3.json
+++ b/Extension Files/manifestv3.json
@@ -1,0 +1,69 @@
+{
+  "manifest_version": 3,
+
+  "name": "iTrace-Chrome Plugin",
+  "description": "Plugin which allows for tracking eyegaze data on webpages in Chrome.",
+  "version": "0.0.1",
+  "content_scripts": [
+    {
+      "js": ["/assets/js/jquery-3.3.1.js"],
+      "matches": ["*://*/*"],
+      "run_at": "document_end"
+    },
+    {
+      "matches": ["*://stackoverflow.com/questions/*"],
+      "js": ["/assets/js/getSOCoordinate.js"]
+    },
+    {
+      "matches": ["*://bugs.eclipse.org/*", "*://bugzilla.mozilla.org/*", "*://bugzilla.kernel.org/*", "*://bz.apache.org/*"],
+      "js": ["/assets/js/getBZCoordinate.js"]
+    },
+    {
+      "matches": ["https://stackoverflow.com/*"],
+      "js": ["/assets/js/getSearchCoordinate.js"]
+    },
+    {
+      "matches": ["https://*.google.com/*"],
+      "js": ["/assets/js/getGoogleCoordinate.js"]
+    },
+    {
+      "matches": ["https://github.com/*/*/issues"],
+      "js": ["/assets/js/getGithubIssueListCoordinate.js"]
+    },
+    {
+      "matches": ["https://github.com/*/*/pulls"],
+      "js": ["/assets/js/getGithubPRListCoordinate.js"]
+    },
+    {
+      "matches": ["https://github.com/*/pull/*"],
+      "js": ["/assets/js/getGithubPullRequestCoordinate.js"]
+    },
+    {
+      "matches": ["https://github.com/*/"],
+      "js": ["/assets/js/getGithubDevProfileCoordinate.js"]
+    },
+    {
+      "matches": ["https://github.com/*tab*"],
+      "js": ["/assets/js/getGithubDevProfileCoordinate.js"]
+    }
+  ],
+  "background": {
+    "service_worker" : "/assets/js/background-wrapper.js"
+  },
+  "action": {
+    "default_icon": {                    
+      "16": "icon16.png",
+      "48": "icon48.png",
+      "128": "icon128.png"
+    },
+    "default_popup": "popup.html"
+  },
+  "permissions": [
+	  "tabs",
+    "activeTab",
+    "downloads"
+  ],
+  "externally_connectable": {
+    "matches": ["*://*.stackoverflow.com/**", "https://stackoverflow.com/*"]
+  }
+}


### PR DESCRIPTION
## Pull Request Description

### Problem

During tests with the Tobii Pro Fusion Eye Tracker, a limitation was identified where the extension failed to properly return user-observed elements, specifically on GitHub pages. The issue manifested as "undefined" values in the fields of the .xml files generated at the end of the execution.

### Solution

To address this limitation, the capturing mechanisms for user-observed elements have been revised. The modification takes into account the unique structure of GitHub pages and ensures accurate retrieval of these elements. The result is reflected in the appropriate sections of the .xml files generated after the completion of tests.

### Changes Made

- Updated the element capturing logic to handle GitHub page structure.
- Ensured proper representation of observed elements in the generated .xml files.
- Conducted thorough testing to validate the changes.

