### PR TITLE
32 empty responses

### DIFF
--- a/Extension Files/assets/js/background.js
+++ b/Extension Files/assets/js/background.js
@@ -117,23 +117,32 @@ const iTraceChrome = {
             iTraceChrome.currentUrl = tabs[0].url;
             // user is looking off screen
             if (!response || response.result == null) {
-                return;
+                var sessionDataItem = {
+                    filename: iTraceChrome.fileLocation,
+                    timestamp: response.time,
+                    current_timestamp: new Date().getTime(),
+                    x: x,
+                    y: y,
+                    relX: response.relX,
+                    relY: response.relY
+                };
+            } else {
+                var sessionDataItem = {
+                    filename: iTraceChrome.fileLocation,
+                    timestamp: response.time,
+                    current_timestamp: new Date().getTime(),
+                    x: x,
+                    y: y,
+                    relX: response.relX,
+                    relY: response.relY,
+                    area: response.result,
+                    line: response.line,
+                    word: response.word,
+                    tagname: response.tagname,
+                    id: response.id,
+                    url: iTraceChrome.currentUrl
+                };
             }
-            var sessionDataItem = {
-                filename: iTraceChrome.fileLocation,
-                timestamp: response.time,
-                current_timestamp: new Date().getTime(),
-                x: x,
-                y: y,
-                relX: response.relX,
-                relY: response.relY,
-                area: response.result,
-                line: response.line,
-                word: response.word,
-                tagname: response.tagname,
-                id: response.id,
-                url: iTraceChrome.currentUrl
-            };
             iTraceChrome.sessionData.push(sessionDataItem);
 
             if (iTraceChrome.db != null) {

--- a/Extension Files/assets/js/background.js
+++ b/Extension Files/assets/js/background.js
@@ -115,22 +115,26 @@ const iTraceChrome = {
     printResults: function (response, x, y) {
         chrome.tabs.query({active: true, currentWindow: true}).then((tabs) => {
             iTraceChrome.currentUrl = tabs[0].url;
-            // user is looking off screen
-            if (!response || response.result == null) {
-                var sessionDataItem = {
+
+            let sessionDataItem;
+            if ((!response || response.result == null) && iTraceChrome.emptyResponsesEnabled) {
+                sessionDataItem = {
+                    aoi_detected: "No_Hit",
                     filename: iTraceChrome.fileLocation,
-                    timestamp: response.time,
-                    current_timestamp: new Date().getTime(),
+                    timestamp: Number(response?.time) || Date.now(),
+                    current_timestamp: Date.now(),
                     x: x,
                     y: y,
-                    relX: response.relX,
-                    relY: response.relY
+                    relX: response?.relX ?? null,
+                    relY: response?.relY ?? null,
+                    url: iTraceChrome.currentUrl
                 };
-            } else {
-                var sessionDataItem = {
+            } else if (response && response.result != null) {
+                sessionDataItem = {
+                    aoi_detected: "AOI_Hit",
                     filename: iTraceChrome.fileLocation,
-                    timestamp: response.time,
-                    current_timestamp: new Date().getTime(),
+                    timestamp: Number(response?.time) || Date.now(),
+                    current_timestamp: Date.now(),
                     x: x,
                     y: y,
                     relX: response.relX,
@@ -143,13 +147,16 @@ const iTraceChrome = {
                     url: iTraceChrome.currentUrl
                 };
             }
-            iTraceChrome.sessionData.push(sessionDataItem);
 
-            if (iTraceChrome.db != null) {
-                var transaction = iTraceChrome.db.transaction(["sessionData"], "readwrite");
+            if (sessionDataItem) {
+                iTraceChrome.sessionData.push(sessionDataItem);
 
-                var objectStore = transaction.objectStore("sessionData");
-                objectStore.add(sessionDataItem)
+                if (iTraceChrome.db != null) {
+                    const transaction = iTraceChrome.db.transaction(["sessionData"], "readwrite");
+
+                    const objectStore = transaction.objectStore("sessionData");
+                    objectStore.add(sessionDataItem)
+                }
             }
         });
     },
@@ -399,6 +406,7 @@ const iTraceChrome = {
                 iTraceState: {
                     id: iTraceChrome.id,
                     fileLocation: iTraceChrome.fileLocation,
+                    emptyResponsesEnabled: iTraceChrome.emptyResponsesEnabled,
                     // viewport vars tell us where the Chrome window begins in the top left corner relative to the screen
                     // They are measured in Css pixels
                     viewportX: iTraceChrome.viewportX,
@@ -492,5 +500,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
     if (message.type === "isActiveITraceChrome") {
         sendResponse(iTraceChrome.isActive);
+    }
+
+    if (message.type === "toggleEmptyResponses") {
+        iTraceChrome.emptyResponsesEnabled = message.enabled;
+
+        chrome.storage.local.set({
+            emptyResponsesEnabled: message.enabled
+        });
+
+        console.log("Empty responses enabled:", iTraceChrome.emptyResponsesEnabled);
     }
 });

--- a/Extension Files/assets/js/getBZCoordinate.js
+++ b/Extension Files/assets/js/getBZCoordinate.js
@@ -88,6 +88,11 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
     }
 
     if (!sentResult) {
-        sendResponse(null);
+        sendResponse({
+                result: null,
+                relX: msg.relX,
+                relY: msg.relY
+            }
+        )
     }
 });

--- a/Extension Files/assets/js/getBZCoordinate.js
+++ b/Extension Files/assets/js/getBZCoordinate.js
@@ -90,6 +90,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
     if (!sentResult) {
         sendResponse({
                 result: null,
+                time: msg.time,
                 relX: msg.relX,
                 relY: msg.relY
             }

--- a/Extension Files/assets/js/getGithubDevProfileCoordinate.js
+++ b/Extension Files/assets/js/getGithubDevProfileCoordinate.js
@@ -290,6 +290,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
     if (!sentResult) {
         sendResponse({
                 result: null,
+                time: msg.time,
                 relX: msg.relX,
                 relY: msg.relY
             }

--- a/Extension Files/assets/js/getGithubDevProfileCoordinate.js
+++ b/Extension Files/assets/js/getGithubDevProfileCoordinate.js
@@ -288,7 +288,12 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         }
     }
     if (!sentResult) {
-        sendResponse(null);
+        sendResponse({
+                result: null,
+                relX: msg.relX,
+                relY: msg.relY
+            }
+        )
     }
 
     // Still need to check: Profile label, URL pattern matching, contribution activity entry, organizations, counters

--- a/Extension Files/assets/js/getGithubIssueListCoordinate.js
+++ b/Extension Files/assets/js/getGithubIssueListCoordinate.js
@@ -168,6 +168,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
     if (!sentResult) {
         sendResponse({
                 result: null,
+                time: msg.time,
                 relX: msg.relX,
                 relY: msg.relY
             }

--- a/Extension Files/assets/js/getGithubIssueListCoordinate.js
+++ b/Extension Files/assets/js/getGithubIssueListCoordinate.js
@@ -166,6 +166,11 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         }
     }
     if (!sentResult) {
-        sendResponse(null);
+        sendResponse({
+                result: null,
+                relX: msg.relX,
+                relY: msg.relY
+            }
+        )
     }
 });

--- a/Extension Files/assets/js/getGithubPRListCoordinate.js
+++ b/Extension Files/assets/js/getGithubPRListCoordinate.js
@@ -253,6 +253,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         // nothing matched
         sendResponse({
                 result: null,
+                time: msg.time,
                 relX: msg.relX,
                 relY: msg.relY
             }
@@ -261,6 +262,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         try {
             sendResponse({
                     result: null,
+                    time: msg.time,
                     relX: msg.relX,
                     relY: msg.relY
                 }

--- a/Extension Files/assets/js/getGithubPRListCoordinate.js
+++ b/Extension Files/assets/js/getGithubPRListCoordinate.js
@@ -251,10 +251,20 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         }
 
         // nothing matched
-        sendResponse(null);
+        sendResponse({
+                result: null,
+                relX: msg.relX,
+                relY: msg.relY
+            }
+        )
     } catch (e) {
         try {
-            sendResponse(null);
+            sendResponse({
+                    result: null,
+                    relX: msg.relX,
+                    relY: msg.relY
+                }
+            )
         } catch (er) {
         }
     }

--- a/Extension Files/assets/js/getGithubPullRequestCoordinate.js
+++ b/Extension Files/assets/js/getGithubPullRequestCoordinate.js
@@ -479,6 +479,11 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         }
     }
     if (!sentResult) {
-        sendResponse(null);
+        sendResponse({
+                result: null,
+                relX: msg.relX,
+                relY: msg.relY
+            }
+        )
     }
 });

--- a/Extension Files/assets/js/getGithubPullRequestCoordinate.js
+++ b/Extension Files/assets/js/getGithubPullRequestCoordinate.js
@@ -481,6 +481,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
     if (!sentResult) {
         sendResponse({
                 result: null,
+                time: msg.time,
                 relX: msg.relX,
                 relY: msg.relY
             }

--- a/Extension Files/assets/js/getGoogleCoordinate.js
+++ b/Extension Files/assets/js/getGoogleCoordinate.js
@@ -69,6 +69,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         console.log("[ContentScript] No matching element found");
         responseData = {
             result: null,
+            time: msg.time,
             relX: msg.relX,
             relY: msg.relY
         };

--- a/Extension Files/assets/js/getGoogleCoordinate.js
+++ b/Extension Files/assets/js/getGoogleCoordinate.js
@@ -67,7 +67,11 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
     if (!responseData) {
         console.log("[ContentScript] No matching element found");
-        responseData = {result: null};
+        responseData = {
+            result: null,
+            relX: msg.relX,
+            relY: msg.relY
+        };
     }
 
     console.log("[ContentScript] Sending response:", responseData);

--- a/Extension Files/assets/js/getSOCoordinate.js
+++ b/Extension Files/assets/js/getSOCoordinate.js
@@ -205,6 +205,10 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
     }
 
     if (!sentResult) {
-        sendResponse(null);
+        sendResponse({
+            result: null,
+            relX: msg.relX,
+            relY: msg.relY
+        })
     }
 });

--- a/Extension Files/assets/js/getSOCoordinate.js
+++ b/Extension Files/assets/js/getSOCoordinate.js
@@ -207,6 +207,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
     if (!sentResult) {
         sendResponse({
             result: null,
+            time: msg.time,
             relX: msg.relX,
             relY: msg.relY
         })

--- a/Extension Files/assets/js/getSearchCoordinate.js
+++ b/Extension Files/assets/js/getSearchCoordinate.js
@@ -87,6 +87,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
     if (!sentResult) {
         sendResponse({
             result: null,
+            time: msg.time,
             relX: msg.relX,
             relY: msg.relY
         })

--- a/Extension Files/assets/js/getSearchCoordinate.js
+++ b/Extension Files/assets/js/getSearchCoordinate.js
@@ -85,6 +85,10 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
     }
 
     if (!sentResult) {
-        sendResponse(null);
+        sendResponse({
+            result: null,
+            relX: msg.relX,
+            relY: msg.relY
+        })
     }
 });

--- a/Extension Files/assets/js/main.js
+++ b/Extension Files/assets/js/main.js
@@ -1,18 +1,18 @@
 /****************************************************************************************************************************
  ****************************
  * @file FILE.EXT
- * 
+ *
  * @copyright (C) 2022 i-trace.org
- * 
+ *
  * This file is part of iTrace Infrastructure http://www.i-trace.org/.
  * iTrace Infrastructure is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
  * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
  * version.
- * 
+ *
  * iTrace Infrastructure is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
  * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along with iTrace Infrastructure. If not, see
  * https://www.gnu.org/licenses/.
  ************************************************************************************************************************
@@ -27,24 +27,53 @@ var _this = this;
 debugger;
 
 
-chrome.runtime.sendMessage({ type: "isInitializedITraceChrome" }, (response) => {
+chrome.runtime.sendMessage({type: "isInitializedITraceChrome"}, (response) => {
     if (!response) {
-        chrome.runtime.sendMessage({ type: "initializeITraceChrome" });
+        chrome.runtime.sendMessage({type: "initializeITraceChrome"});
     }
 });
 
-$(document).ready(function() {
-    $("#start_session").on("click", function(event) {
-        chrome.tabs.query({ active: true, currentWindow: true}).then((tabs) => {chrome.runtime.sendMessage({ type: "startSessionITraceChrome", vars: [tabs] }, () => {
-            $("#session_status").html("Session Started - Attempting to Connect");
-        });});
-    });
-    
-    $("#write_xml").on("click", function(event) {
-        chrome.runtime.sendMessage({ type: "writeXMLDataITraceChrome" });
+$(document).ready(function () {
+    $("#start_session").on("click", function (event) {
+        chrome.tabs.query({active: true, currentWindow: true}).then((tabs) => {
+            chrome.runtime.sendMessage({type: "startSessionITraceChrome", vars: [tabs]}, () => {
+                $("#session_status").html("Session Started - Attempting to Connect");
+            });
+        });
     });
 
-    chrome.runtime.sendMessage({ type: "isActiveITraceChrome"}, (response) => {
+    $("#write_xml").on("click", function (event) {
+        chrome.runtime.sendMessage({type: "writeXMLDataITraceChrome"});
+    });
+
+    $("#config").on("click", function () {
+        $("#main_window").hide();
+        $("#config_window").show();
+        $("#config").hide();
+        $("#back_to_main").show();
+    });
+
+    $("#back_to_main").on("click", function () {
+        $("#config_window").hide();
+        $("#main_window").show();
+        $("#back_to_main").hide();
+        $("#config").show();
+    });
+
+    $("#empty_responses").on("change", function () {
+        const enabled = $(this).is(":checked");
+
+        chrome.runtime.sendMessage({
+            type: "toggleEmptyResponses",
+            enabled: enabled
+        });
+    });
+
+    chrome.storage.local.get("emptyResponsesEnabled", (data) => {
+        $("#empty_responses").prop("checked", data.emptyResponsesEnabled || false);
+    });
+
+    chrome.runtime.sendMessage({type: "isActiveITraceChrome"}, (response) => {
         if (response) {
             $("#session_status").html("Session Started - Connected");
         }

--- a/Extension Files/popup.html
+++ b/Extension Files/popup.html
@@ -1,18 +1,25 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>iTrace-Chrome Plugin</title>
-        <script src="assets/js/jquery-3.3.1.js"></script>
-        <script src="assets/js/lodash.js"></script>
-        <script src="assets/js/main.js"></script>
-    </head>
-    <body>
-        <div style="width:500px; border: 1px solid black">
-            Click Button Below to Connect To Server
-            <button id="start_session">Start</button>
-            <div id="session_status">Not Connected To Core</div>
-        </div>
-        <hr/>
-        <button id="write_xml">Write XML Data</button>
-    </body>
+<head>
+    <title>iTrace-Chrome Plugin</title>
+    <script src="assets/js/jquery-3.3.1.js"></script>
+    <script src="assets/js/lodash.js"></script>
+    <script src="assets/js/main.js"></script>
+</head>
+<body>
+<div id="main_window" style="width:500px; border: 1px solid black">
+    Click Button Below to Connect To Server
+    <button id="start_session">Start</button>
+    <div id="session_status">Not Connected To Core</div>
+</div>
+
+<div id="config_window" style="width:500px; border: 1px solid black; display:none;">
+    <label for="empty_responses">Empty Script Response</label>
+    <input id="empty_responses" type="checkbox">
+</div>
+<hr/>
+<button id="write_xml">Write XML Data</button>
+<button id="config">Config</button>
+<button id="back_to_main" style="display: none">Back</button>
+</body>
 </html>


### PR DESCRIPTION
This PR adds two notable features to iTrace Chrome

1. An Empty Script Responses feature has been added to iTrace Chrome. Currently, when iTrace Core sends a gaze package to iTrace Chrome, if the gaze is determined to not be inside any AOIs, the gaze is discarded. The Empty Script Responses feature allows these gazes to be added to the XML instead of being discarded. They are considered "empty" as they are not part of an AOI, and are denoted by the "No_Hit" value in the  <aoi_detected> field.
2. A new Config menu is added in the popup. Currently this menu only contains a toggle button for the empty script responses feature, but there will be more options added feature.