### PR TITLE
29 request listener

### DIFF
--- a/Extension Files/assets/js/background.js
+++ b/Extension Files/assets/js/background.js
@@ -216,6 +216,42 @@ const iTraceChrome = {
         }
     },
 
+    messageScript: function (tabId, url, coords, timeStamp, x, y) {
+        let messageType = null;
+
+        if (url.includes('stackoverflow.com/questions/')) {
+            messageType = 'get_so_coordinate';
+        } else if (url.includes('https://bug')) {
+            messageType = 'get_bz_coordinate';
+        } else if (url.includes('stackoverflow.com/search')) {
+            messageType = 'get_search_coordinate';
+        } else if (url.includes('google.com')) {
+            messageType = 'get_google_coordinate';
+        } else if (url.includes('github.com') && url.includes('/issues')) {
+            messageType = 'get_github_issues_coordinate';
+        } else if (url.includes('github.com') && url.includes('/pulls')) {
+            messageType = 'get_github_prlist_coordinate';
+        } else if (url.includes('github.com') && url.includes('/pull/')) {
+            messageType = 'get_github_pr_coordinate';
+        } else if (url.includes('github.com')) {
+            messageType = 'get_github_dev_profile_coordinate';
+        }
+
+        if (!messageType) return;
+
+        chrome.tabs.sendMessage(tabId, {
+            text: messageType,
+            relX: coords.relX,
+            relY: coords.relY,
+            time: timeStamp,
+            url: url
+        }).then(response => {
+            iTraceChrome.printResults(response, x, y);
+        }).catch(err => {
+            console.warn("Content script not ready:", err);
+        });
+    },
+
     // this function deals with incoming eyegaze data
     webSocketHandler: function (e) {
         var eyeGazeData = e.data;
@@ -251,107 +287,7 @@ const iTraceChrome = {
             // user is looking in the html viewport
             // need to check which website the user is looking at
             chrome.tabs.query({active: true, currentWindow: true}).then((tabs) => {
-                let url = tabs[0].url;
-                console.log(tabs[0].url);
-                if (url.includes('stackoverflow.com/questions/')) {
-                    chrome.tabs.sendMessage(iTraceChrome.id, {
-                        text: 'get_so_coordinate',
-                        relX: coords.relX,
-                        relY: coords.relY,
-                        time: timeStamp,
-                        url: url
-                    }).then(response => {
-                        iTraceChrome.printResults(response, x, y);
-                    });
-                }
-                if (url.includes('https://bug')) { // NOTE: This include may be incorect, will need to do some more research
-                    chrome.tabs.sendMessage(iTraceChrome.id, {
-                        text: 'get_bz_coordinate',
-                        relX: coords.relX,
-                        relY: coords.relY,
-                        time: timeStamp,
-                        url: url
-                    }).then(response => {
-                        iTraceChrome.printResults(response, x, y);
-                    });
-                }
-                if (url.includes('stackoverflow.com/search')) {
-                    chrome.tabs.sendMessage(iTraceChrome.id, {
-                        text: 'get_search_coordinate',
-                        relX: coords.relX,
-                        relY: coords.relY,
-                        time: timeStamp,
-                        url: url
-                    }).then(response => {
-                        iTraceChrome.printResults(response, x, y);
-                    });
-                }
-                if (url.includes('google.com')) {
-                    chrome.tabs.sendMessage(iTraceChrome.id, {
-                        text: 'get_google_coordinate',
-                        relX: coords.relX,
-                        relY: coords.relY,
-                        time: timeStamp,
-                        url: url
-                    }).then(response => {
-                        iTraceChrome.printResults(response, x, y);
-                    });
-                }
-                if (url.includes('github.com/*/*/issues')) {
-                    chrome.tabs.sendMessage(iTraceChrome.id, {
-                        text: 'get_github_issues_coordinate',
-                        relX: coords.relX,
-                        relY: coords.relY,
-                        time: timeStamp,
-                        url: url
-                    }).then(response => {
-                        iTraceChrome.printResults(response, x, y);
-                    });
-                }
-                if (url.includes('github.com/*/*/pulls')) {
-                    chrome.tabs.sendMessage(iTraceChrome.id, {
-                        text: 'get_github_prlist_coordinate',
-                        relX: coords.relX,
-                        relY: coords.relY,
-                        time: timeStamp,
-                        url: url
-                    }).then(response => {
-                        iTraceChrome.printResults(response, x, y);
-                    });
-                }
-                if (url.includes('github.com/*/*/pull')) {
-                    chrome.tabs.sendMessage(iTraceChrome.id, {
-                        text: 'get_github_pr_coordinate',
-                        relX: coords.relX,
-                        relY: coords.relY,
-                        time: timeStamp,
-                        url: url
-                    }).then(response => {
-                        iTraceChrome.printResults(response, x, y);
-                    });
-                }
-                if (url.includes('github.com') && url.includes('pull')) {
-                    chrome.tabs.sendMessage(iTraceChrome.id, {
-                        text: 'get_github_pr_coordinate',
-                        relX: coords.relX,
-                        relY: coords.relY,
-                        time: timeStamp,
-                        url: url
-                    }).then(response => {
-                        iTraceChrome.printResults(response, x, y);
-                    });
-                }
-                if (url.includes('github.com/')) {
-                    chrome.tabs.sendMessage(iTraceChrome.id, {
-                        text: 'get_github_dev_profile_coordinate',
-                        relX: coords.relX,
-                        relY: coords.relY,
-                        time: timeStamp,
-                        url: url
-                    }).then(response => {
-                        iTraceChrome.printResults(response, x, y);
-                    });
-                }
+                this.messageScript(tabs[0].id, tabs[0].url, coords, timeStamp, x, y);
             });
         }
     },
@@ -510,5 +446,38 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         });
 
         console.log("Empty responses enabled:", iTraceChrome.emptyResponsesEnabled);
+    }
+});
+
+chrome.webNavigation.onHistoryStateUpdated.addListener((details) => {
+    const {tabId, url} = details;
+
+    if (!url) return;
+
+    let file = null;
+
+    if (url.includes('stackoverflow.com/questions/')) {
+        file = '/assets/js/getSOCoordinate.js';
+    } else if (url.includes('stackoverflow.com/search')) {
+        file = '/assets/js/getSearchCoordinate.js';
+    } else if (url.includes('https://bug')) {
+        file = '/assets/js/getBZCoordinate.js';
+    } else if (url.includes('google.com')) {
+        file = '/assets/js/getGoogleCoordinate.js';
+    } else if (url.includes('github.com') && url.includes('/issues')) {
+        file = '/assets/js/getGithubIssueListCoordinate.js';
+    } else if (url.includes('github.com') && url.includes('/pulls')) {
+        file = '/assets/js/getGithubPRListCoordinate.js';
+    } else if (url.includes('github.com') && url.includes('/pull/')) {
+        file = '/assets/js/getGithubPullRequestCoordinate.js';
+    } else if (url.includes('github.com')) {
+        file = '/assets/js/getGithubDevProfileCoordinate.js';
+    }
+
+    if (file) {
+        chrome.scripting.executeScript({
+            target: {tabId},
+            files: [file]
+        });
     }
 });

--- a/Extension Files/assets/js/background.js
+++ b/Extension Files/assets/js/background.js
@@ -420,39 +420,8 @@ const iTraceChrome = {
     db: null
 }
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (message.type === "isInitializedITraceChrome") {
-        sendResponse(iTraceChrome.isInitialized);
-    }
-    if (message.type === "initializeITraceChrome") {
-        iTraceChrome.initialize()
-    }
-    if (message.type === "writeXMLDataITraceChrome") {
-        console.log("writeXMLDataITraceChrome");
-        iTraceChrome.writeXMLData();
-    }
-    if (message.type === "startSessionITraceChrome") {
-        iTraceChrome.startSession(message.vars[0]);
-    }
-    if (message.type === "isActiveITraceChrome") {
-        sendResponse(iTraceChrome.isActive);
-    }
+function injectScriptForUrl(tabId, url) {
 
-    if (message.type === "toggleEmptyResponses") {
-        iTraceChrome.emptyResponsesEnabled = message.enabled;
-
-        chrome.storage.local.set({
-            emptyResponsesEnabled: message.enabled
-        });
-
-        console.log("Empty responses enabled:", iTraceChrome.emptyResponsesEnabled);
-    }
-});
-
-chrome.webNavigation.onHistoryStateUpdated.addListener((details) => {
-    const {tabId, url} = details;
-
-    if (!url) return;
 
     let file = null;
 
@@ -460,7 +429,7 @@ chrome.webNavigation.onHistoryStateUpdated.addListener((details) => {
         file = '/assets/js/getSOCoordinate.js';
     } else if (url.includes('stackoverflow.com/search')) {
         file = '/assets/js/getSearchCoordinate.js';
-    } else if (url.includes('https://bug')) {
+    } else if (url.includes('bugzilla') || url.includes('bugs.eclipse.org') || url.includes('bz.apache.org')) {
         file = '/assets/js/getBZCoordinate.js';
     } else if (url.includes('google.com')) {
         file = '/assets/js/getGoogleCoordinate.js';
@@ -474,10 +443,52 @@ chrome.webNavigation.onHistoryStateUpdated.addListener((details) => {
         file = '/assets/js/getGithubDevProfileCoordinate.js';
     }
 
-    if (file) {
-        chrome.scripting.executeScript({
-            target: {tabId},
-            files: [file]
-        });
+    if (!file) return;
+    console.log("Injected:", file, url);
+    chrome.scripting.executeScript({
+        target: {tabId},
+        files: [file]
+    }).catch(err => {
+        console.warn("Injection failed:", err);
+    });
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+        if (message.type === "isInitializedITraceChrome") {
+            sendResponse(iTraceChrome.isInitialized);
+        }
+        if (message.type === "initializeITraceChrome") {
+            iTraceChrome.initialize()
+        }
+        if (message.type === "writeXMLDataITraceChrome") {
+            console.log("writeXMLDataITraceChrome");
+            iTraceChrome.writeXMLData();
+        }
+        if (message.type === "startSessionITraceChrome") {
+            iTraceChrome.startSession(message.vars[0]);
+        }
+        if (message.type === "isActiveITraceChrome") {
+            sendResponse(iTraceChrome.isActive);
+        }
+
+        if (message.type === "toggleEmptyResponses") {
+            iTraceChrome.emptyResponsesEnabled = message.enabled;
+
+            chrome.storage.local.set({
+                emptyResponsesEnabled: message.enabled
+            });
+
+            console.log("Empty responses enabled:", iTraceChrome.emptyResponsesEnabled);
+        }
+    }
+)
+
+chrome.webNavigation.onHistoryStateUpdated.addListener((details) => {
+    injectScriptForUrl(details.tabId, details.url);
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (changeInfo.status === "complete" && tab.url) {
+        injectScriptForUrl(tabId, tab.url);
     }
 });

--- a/Extension Files/assets/js/background.js
+++ b/Extension Files/assets/js/background.js
@@ -19,6 +19,9 @@
  ********************************/
 // importScripts("jquery-3.3.1.js");
 // main JavaScript driver for the iTrace-Chrome plugin, all data will be handled here
+
+reinjectAllTabs();
+
 chrome.runtime.onStartup.addListener(() => {
     chrome.storage.local.get("iTraceState", (data) => {
         if (data.iTraceState) {
@@ -26,6 +29,7 @@ chrome.runtime.onStartup.addListener(() => {
         }
     });
 });
+
 const iTraceChrome = {
     // this function takes the x and y coordinates from the screen and the browser
     // to get the offset, which then returns the translated coordinates based off if the user
@@ -248,7 +252,17 @@ const iTraceChrome = {
         }).then(response => {
             iTraceChrome.printResults(response, x, y);
         }).catch(err => {
-            console.warn("Content script not ready:", err);
+            if (
+                err.message &&
+                err.message.includes("Receiving end does not exist")
+            ) {
+
+                chrome.tabs.get(tabId, (tab) => {
+                    if (tab?.url) {
+                        injectScriptForUrl(tabId, tab.url);
+                    }
+                });
+            }
         });
     },
 
@@ -421,8 +435,6 @@ const iTraceChrome = {
 }
 
 function injectScriptForUrl(tabId, url) {
-
-
     let file = null;
 
     if (url.includes('stackoverflow.com/questions/')) {
@@ -450,6 +462,16 @@ function injectScriptForUrl(tabId, url) {
         files: [file]
     }).catch(err => {
         console.warn("Injection failed:", err);
+    });
+}
+
+function reinjectAllTabs() {
+    chrome.tabs.query({}, (tabs) => {
+        tabs.forEach((tab) => {
+            if (tab.id && tab.url) {
+                injectScriptForUrl(tab.id, tab.url);
+            }
+        });
     });
 }
 

--- a/Extension Files/assets/js/background.js
+++ b/Extension Files/assets/js/background.js
@@ -507,14 +507,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 chrome.webNavigation.onHistoryStateUpdated.addListener((details) => {
     injectScriptForUrl(details.tabId, details.url);
-    console.log("History Injected:", details.url);
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    console.log("TAB UPDATE", changeInfo);
-
     if (changeInfo.status === "complete" && tab.url) {
-        injectScriptForUrl(tabId, tab.url);
-        console.log("Update Injected:", tab.url);
+        injectScriptForUrl(tabId, tab.url);;
     }
 });

--- a/Extension Files/assets/js/background.js
+++ b/Extension Files/assets/js/background.js
@@ -485,10 +485,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 chrome.webNavigation.onHistoryStateUpdated.addListener((details) => {
     injectScriptForUrl(details.tabId, details.url);
+    console.log("History Injected:", details.url);
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    console.log("TAB UPDATE", changeInfo);
+
     if (changeInfo.status === "complete" && tab.url) {
         injectScriptForUrl(tabId, tab.url);
+        console.log("Update Injected:", tab.url);
     }
 });

--- a/Extension Files/assets/js/getBZCoordinate.js
+++ b/Extension Files/assets/js/getBZCoordinate.js
@@ -18,82 +18,87 @@
  ************************************************************************************************************************
  ********************************/
 
-console.log('Get BZ Coordinates Script Started');
-
 // listens for data of the different BZ columns and the data associated with and logs it
-chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
-    var elements = document.elementsFromPoint(msg.relX, msg.relY);
+if (window.iTrace_getBZCoordinate_Loaded) {
+} else {
+    window.iTrace_getBZCoordinate_Loaded = true;
+    console.log('Get BZ Coordinates Script Started');
 
-    var sentResult = false;
-    for (element of elements) {
-        if (element.classList.contains('module-categories')) {
-            console.log('question info - categories');
-            sentResult = true;
-            sendResponse({
-                result: 'question info - categories',
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                tagname: element.tagName,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
+    chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
 
-        if (element.id === 'module-tracking') {
-            console.log('question info - tracking');
-            sentResult = true;
-            sendResponse({
-                result: 'question info - tracking',
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                tagname: element.tagName,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
+        var elements = document.elementsFromPoint(msg.relX, msg.relY);
 
-        if (element.classList.contains('comment-text')) {
-            console.log('answer info');
-            sentResult = true;
-            sendResponse({
-                result: 'answer info',
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                tagname: element.tagName,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-
-        if (element.tagName == 'TR') {
-            console.log('attachment info');
-            sentResult = true;
-            sendResponse({
-                result: 'attachment info',
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                tagname: element.tagName,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-    }
-
-    if (!sentResult) {
-        sendResponse({
-                result: null,
-                time: msg.time,
-                relX: msg.relX,
-                relY: msg.relY
+        var sentResult = false;
+        for (element of elements) {
+            if (element.classList.contains('module-categories')) {
+                console.log('question info - categories');
+                sentResult = true;
+                sendResponse({
+                    result: 'question info - categories',
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    tagname: element.tagName,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
             }
-        )
-    }
-});
+
+            if (element.id === 'module-tracking') {
+                console.log('question info - tracking');
+                sentResult = true;
+                sendResponse({
+                    result: 'question info - tracking',
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    tagname: element.tagName,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+
+            if (element.classList.contains('comment-text')) {
+                console.log('answer info');
+                sentResult = true;
+                sendResponse({
+                    result: 'answer info',
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    tagname: element.tagName,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+
+            if (element.tagName == 'TR') {
+                console.log('attachment info');
+                sentResult = true;
+                sendResponse({
+                    result: 'attachment info',
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    tagname: element.tagName,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+        }
+
+        if (!sentResult) {
+            sendResponse({
+                    result: null,
+                    time: msg.time,
+                    relX: msg.relX,
+                    relY: msg.relY
+                }
+            )
+        }
+    });
+}

--- a/Extension Files/assets/js/getGithubDevProfileCoordinate.js
+++ b/Extension Files/assets/js/getGithubDevProfileCoordinate.js
@@ -17,285 +17,288 @@
  * https://www.gnu.org/licenses/.
  ************************************************************************************************************************
  ********************************/
-
-console.log('Developer Profile Script Started');
+if (window.iTrace_getGithubDevProfileCoordinate_Loaded) {
+} else {
+    window.iTrace_getGithubDevProfileCoordinate_Loaded = true;
+    console.log('Developer Profile Script Started');
 
 // listens for data from different GitHub profile attributes then sends a response based on its results
-chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
-    const elements = document.elementsFromPoint(msg.relX, msg.relY);
-    let sentResult = false;
-    for (element of elements) {
-        // Avatar
-        if (element.classList.contains("d-block") && element.tagName === 'A') {
-            console.log('Avatar Image');
+    chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
+        const elements = document.elementsFromPoint(msg.relX, msg.relY);
+        let sentResult = false;
+        for (element of elements) {
+            // Avatar
+            if (element.classList.contains("d-block") && element.tagName === 'A') {
+                console.log('Avatar Image');
 
-            const avatarHref = element.getAttribute('href') || '';
+                const avatarHref = element.getAttribute('href') || '';
 
-            sentResult = true;
-            sendResponse({
-                result: `AvatarImage-${avatarHref}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Activity overview (deprecated?)
-        if (element.classList.contains("js-activity-overview-graph-container") && element.attributes.getNamedItem('data-percentages')) {
-            console.log("Activity Overview");
-            let activityOverview = element.attributes.getNamedItem('data-percentages').value;
-            activityOverview = JSON.parse(activityOverview);
-            const percentCommits = activityOverview["Commits"];
-            const percentCodeReview = activityOverview["Code review"];
-            const percentPullRequests = activityOverview["Pull requests"];
-            sentResult = true;
-            sendResponse({
-                result: `ActivityOverview-Commit:${percentCommits}%,CodeReview:${percentCodeReview}%,PullRequest:${percentPullRequests}%`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Contribution heat map
-        if (element.tagName === 'DIV' && element.classList.contains("graph-before-activity-overview")) {
-            console.log('Contribution Heat Map')
-            sentResult = true;
-            sendResponse({
-                result: `ContributionHeatMap`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Year link
-        if (element.id.includes("year-link")) {
-            console.log('Year Link')
-            const year = element.innerHTML;
-            sentResult = true;
-            sendResponse({
-                result: `Year-${year}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Profile label (depcrecated?)
-        if (element.tagName === 'SPAN' && element.classList.contains("label")) {
-            console.log('Profile Label')
-            const labelName = element.innerHTML;
-            sentResult = true;
-            sendResponse({
-                result: `ProfileLabel-${labelName}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Profile bio
-        if (element.tagName === 'DIV' && element.classList.contains("user-profile-bio")) {
-            console.log('Profile Bio')
-            const bioText = element.innerText;
-            sentResult = true;
-            sendResponse({
-                result: `ProfileBio-${bioText}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Follower count
-        if (element.tagName === 'DIV' && element.classList.contains("flex-order-1") && element.classList.contains("mt-md-0")) {
-            console.log('Follower Count')
-            const followerLink = element.querySelector('a[href$="?tab=followers"]');
-            const followerCount = followerLink.querySelector('span').innerHTML;
-            const followingLink = element.querySelector('a[href$="?tab=following"]');
-            const followingCount = followingLink.querySelector('span').innerHTML;
-
-            sentResult = true;
-            sendResponse({
-                result: `FollowerCount-${followerCount} followers, ${followingCount} following`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Profile details section
-        if (element.tagName === 'UL' && element.classList.contains("vcard-details")) {
-            console.log('Profile Details Section')
-            sentResult = true;
-            sendResponse({
-                result: `VcardSection`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Achievements section
-        if (element.tagName === 'DIV' && element.classList.contains("border-top") && element.querySelector("h2")?.textContent.includes("Achievements")) {
-            console.log('Achievements Section')
-            sentResult = true;
-            sendResponse({
-                result: `AchievementsSection`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Highlights section
-        if (element.tagName === 'DIV' && element.classList.contains("border-top") && element.querySelector("h2")?.textContent.includes("Highlights")) {
-            console.log('Highlights Section')
-            sentResult = true;
-            sendResponse({
-                result: `HighlightsSection`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Organization icon and link
-        // if (element.tagName === 'A' && element.attributes.getNamedItem("data-hovercard-type") && element.attributes.getNamedItem("data-hovercard-type").value === "organization"
-        // && element.classList.contains("avatar-group-item")) {
-        if (element.classList.contains("pt-3") && element.classList.contains("clearfix")) {
-            console.log('Organizations Section');
-            // const organizationName = element.attributes.getNamedItem("aria-label").value;
-            sentResult = true;
-            sendResponse({
-                result: `Organizations`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Contributed repository link (deprecated?)
-        if (element.tagName === 'A' && element.attributes.getNamedItem("itemprop") && element.attributes.getNamedItem("itemprop").value.includes("codeRepository")) {
-            console.log('Contributed repositories')
-            const repoName = element.innerHTML;
-            sentResult = true;
-            sendResponse({
-                result: `Repository-${repoName}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Pinned repository link
-        if (element.tagName === 'DIV' && element.classList.contains("public") && element.classList.contains("source")) {
-            console.log('Pinned Repository')
-
-            const repoLink = element.querySelector('a.Link.text-bold');
-            let ownerRepo = '';
-            if (repoLink) {
-                const ownerSpan = repoLink.querySelector('span.owner');
-                const repoSpan = repoLink.querySelector('span.repo');
-                const owner = ownerSpan ? ownerSpan.textContent.trim() : '';
-                const repo = repoSpan ? repoSpan.textContent.trim() : '';
-                ownerRepo = `${owner}${repo}`; // e.g., "iTrace-Dev/iTrace-Toolkit"
+                sentResult = true;
+                sendResponse({
+                    result: `AvatarImage-${avatarHref}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
             }
-
-            sentResult = true;
-            sendResponse({
-                result: `PinnedRepository-${ownerRepo}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // tab and counter
-        if (element.classList.contains("Counter")) {
-            console.log("Tab Counter")
-            const tab = element.parentElement.innerHTML;
-            const number = element.innerHTML
-            sentResult = true;
-            sendResponse({
-                result: `Num${tab}-${number}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // tab but no counter
-        if (element.classList.contains("UnderlineNav-item")) {
-            const tabName = element.innerText.replace(/\s+/g, ' ').trim(); // clean up whitespace
-            console.log(`Tab (no counter) ${tabName}`)
-            sentResult = true;
-            sendResponse({
-                result: `Tab-${tabName}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Contribution activity entry
-        if (element.classList.contains("TimelineItem")) {
-            console.log("Contribution Activity Entry");
-            const summary = element.querySelector("h4 span.color-fg-default");
-            activityText = summary ? summary.textContent.trim() : '';
-
-            sentResult = true;
-            sendResponse({
-                result: `ContributionActivity-${activityText}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-    }
-    if (!sentResult) {
-        sendResponse({
-                result: null,
-                time: msg.time,
-                relX: msg.relX,
-                relY: msg.relY
+            // Activity overview (deprecated?)
+            if (element.classList.contains("js-activity-overview-graph-container") && element.attributes.getNamedItem('data-percentages')) {
+                console.log("Activity Overview");
+                let activityOverview = element.attributes.getNamedItem('data-percentages').value;
+                activityOverview = JSON.parse(activityOverview);
+                const percentCommits = activityOverview["Commits"];
+                const percentCodeReview = activityOverview["Code review"];
+                const percentPullRequests = activityOverview["Pull requests"];
+                sentResult = true;
+                sendResponse({
+                    result: `ActivityOverview-Commit:${percentCommits}%,CodeReview:${percentCodeReview}%,PullRequest:${percentPullRequests}%`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
             }
-        )
-    }
+            // Contribution heat map
+            if (element.tagName === 'DIV' && element.classList.contains("graph-before-activity-overview")) {
+                console.log('Contribution Heat Map')
+                sentResult = true;
+                sendResponse({
+                    result: `ContributionHeatMap`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Year link
+            if (element.id.includes("year-link")) {
+                console.log('Year Link')
+                const year = element.innerHTML;
+                sentResult = true;
+                sendResponse({
+                    result: `Year-${year}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Profile label (depcrecated?)
+            if (element.tagName === 'SPAN' && element.classList.contains("label")) {
+                console.log('Profile Label')
+                const labelName = element.innerHTML;
+                sentResult = true;
+                sendResponse({
+                    result: `ProfileLabel-${labelName}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Profile bio
+            if (element.tagName === 'DIV' && element.classList.contains("user-profile-bio")) {
+                console.log('Profile Bio')
+                const bioText = element.innerText;
+                sentResult = true;
+                sendResponse({
+                    result: `ProfileBio-${bioText}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Follower count
+            if (element.tagName === 'DIV' && element.classList.contains("flex-order-1") && element.classList.contains("mt-md-0")) {
+                console.log('Follower Count')
+                const followerLink = element.querySelector('a[href$="?tab=followers"]');
+                const followerCount = followerLink.querySelector('span').innerHTML;
+                const followingLink = element.querySelector('a[href$="?tab=following"]');
+                const followingCount = followingLink.querySelector('span').innerHTML;
 
-    // Still need to check: Profile label, URL pattern matching, contribution activity entry, organizations, counters
-});
+                sentResult = true;
+                sendResponse({
+                    result: `FollowerCount-${followerCount} followers, ${followingCount} following`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Profile details section
+            if (element.tagName === 'UL' && element.classList.contains("vcard-details")) {
+                console.log('Profile Details Section')
+                sentResult = true;
+                sendResponse({
+                    result: `VcardSection`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Achievements section
+            if (element.tagName === 'DIV' && element.classList.contains("border-top") && element.querySelector("h2")?.textContent.includes("Achievements")) {
+                console.log('Achievements Section')
+                sentResult = true;
+                sendResponse({
+                    result: `AchievementsSection`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Highlights section
+            if (element.tagName === 'DIV' && element.classList.contains("border-top") && element.querySelector("h2")?.textContent.includes("Highlights")) {
+                console.log('Highlights Section')
+                sentResult = true;
+                sendResponse({
+                    result: `HighlightsSection`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Organization icon and link
+            // if (element.tagName === 'A' && element.attributes.getNamedItem("data-hovercard-type") && element.attributes.getNamedItem("data-hovercard-type").value === "organization"
+            // && element.classList.contains("avatar-group-item")) {
+            if (element.classList.contains("pt-3") && element.classList.contains("clearfix")) {
+                console.log('Organizations Section');
+                // const organizationName = element.attributes.getNamedItem("aria-label").value;
+                sentResult = true;
+                sendResponse({
+                    result: `Organizations`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Contributed repository link (deprecated?)
+            if (element.tagName === 'A' && element.attributes.getNamedItem("itemprop") && element.attributes.getNamedItem("itemprop").value.includes("codeRepository")) {
+                console.log('Contributed repositories')
+                const repoName = element.innerHTML;
+                sentResult = true;
+                sendResponse({
+                    result: `Repository-${repoName}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Pinned repository link
+            if (element.tagName === 'DIV' && element.classList.contains("public") && element.classList.contains("source")) {
+                console.log('Pinned Repository')
+
+                const repoLink = element.querySelector('a.Link.text-bold');
+                let ownerRepo = '';
+                if (repoLink) {
+                    const ownerSpan = repoLink.querySelector('span.owner');
+                    const repoSpan = repoLink.querySelector('span.repo');
+                    const owner = ownerSpan ? ownerSpan.textContent.trim() : '';
+                    const repo = repoSpan ? repoSpan.textContent.trim() : '';
+                    ownerRepo = `${owner}${repo}`; // e.g., "iTrace-Dev/iTrace-Toolkit"
+                }
+
+                sentResult = true;
+                sendResponse({
+                    result: `PinnedRepository-${ownerRepo}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // tab and counter
+            if (element.classList.contains("Counter")) {
+                console.log("Tab Counter")
+                const tab = element.parentElement.innerHTML;
+                const number = element.innerHTML
+                sentResult = true;
+                sendResponse({
+                    result: `Num${tab}-${number}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // tab but no counter
+            if (element.classList.contains("UnderlineNav-item")) {
+                const tabName = element.innerText.replace(/\s+/g, ' ').trim(); // clean up whitespace
+                console.log(`Tab (no counter) ${tabName}`)
+                sentResult = true;
+                sendResponse({
+                    result: `Tab-${tabName}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Contribution activity entry
+            if (element.classList.contains("TimelineItem")) {
+                console.log("Contribution Activity Entry");
+                const summary = element.querySelector("h4 span.color-fg-default");
+                activityText = summary ? summary.textContent.trim() : '';
+
+                sentResult = true;
+                sendResponse({
+                    result: `ContributionActivity-${activityText}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+        }
+        if (!sentResult) {
+            sendResponse({
+                    result: null,
+                    time: msg.time,
+                    relX: msg.relX,
+                    relY: msg.relY
+                }
+            )
+        }
+
+        // Still need to check: Profile label, URL pattern matching, contribution activity entry, organizations, counters
+    });
+}

--- a/Extension Files/assets/js/getGithubIssueListCoordinate.js
+++ b/Extension Files/assets/js/getGithubIssueListCoordinate.js
@@ -28,10 +28,8 @@ if (window.iTrace_getGithubIssueListCoordinate_Loaded) {
         const elements = document.elementsFromPoint(msg.relX, msg.relY);
         let sentResult = false;
         for (element of elements) {
-            console.log("looping");
             if (element.tagName === 'A' && element.querySelector('div')?.textContent.trim() === 'Open') {
                 const numberOpen = element.querySelector('span[aria-hidden="true"]')?.textContent.trim();
-                console.log('Number of Open issues:', numberOpen);
                 sentResult = true;
                 sendResponse({
                     result: `NumIssuesOpen-${numberOpen}`,
@@ -50,7 +48,6 @@ if (window.iTrace_getGithubIssueListCoordinate_Loaded) {
                 const type = element.getAttribute("data-hovercard-type");
                 // This may need to be changed to include project names
                 if (type === "organization") {
-                    console.log("Project/Organization Name");
 
                     const organization = element.textContent.trim();
 
@@ -65,7 +62,6 @@ if (window.iTrace_getGithubIssueListCoordinate_Loaded) {
                     });
                     return;
                 } else if (type === 'user') {
-                    console.log('user link')
                     const user = element.innerHTML;
                     sentResult = true;
                     sendResponse({
@@ -84,7 +80,6 @@ if (window.iTrace_getGithubIssueListCoordinate_Loaded) {
                 element.tagName === "A" &&
                 element.getAttribute("data-testid") === "issue-pr-title-link"
             ) {
-                console.log('issue link')
                 const title = element.textContent.trim();
                 sentResult = true;
                 sendResponse({
@@ -123,7 +118,6 @@ if (window.iTrace_getGithubIssueListCoordinate_Loaded) {
                     element.href.includes("/labels/")
                 )
             ) {
-                console.log('Issue label')
                 const labelTitle = element.innerHTML;
                 sentResult = true;
                 sendResponse({
@@ -137,7 +131,6 @@ if (window.iTrace_getGithubIssueListCoordinate_Loaded) {
                 return;
             }
             if (element.tagName === 'RELATIVE-TIME') {
-                console.log('Time open')
                 const opened = element.innerHTML;
                 const timestamp = element.attributes.getNamedItem('title').value;
                 sentResult = true;

--- a/Extension Files/assets/js/getGithubIssueListCoordinate.js
+++ b/Extension Files/assets/js/getGithubIssueListCoordinate.js
@@ -17,44 +17,24 @@
  * https://www.gnu.org/licenses/.
  ************************************************************************************************************************
  ********************************/
-
-console.log('Github Issues Script Started');
+if (window.iTrace_getGithubIssueListCoordinate_Loaded) {
+} else {
+    window.iTrace_getGithubIssueListCoordinate_Loaded = true;
+    console.log('Github Issues Script Started');
 
 // listens for the different GitHub issue coordinates and data associated with it, then sends
 // response based on its results
-chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
-    const elements = document.elementsFromPoint(msg.relX, msg.relY);
-    let sentResult = false;
-    for (element of elements) {
-        console.log("looping");
-        if (element.tagName === 'A' && element.querySelector('div')?.textContent.trim() === 'Open') {
-            const numberOpen = element.querySelector('span[aria-hidden="true"]')?.textContent.trim();
-            console.log('Number of Open issues:', numberOpen);
-            sentResult = true;
-            sendResponse({
-                result: `NumIssuesOpen-${numberOpen}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        if (
-            element.tagName === "A" &&
-            element.hasAttribute("data-hovercard-type")
-        ) {
-            const type = element.getAttribute("data-hovercard-type");
-            // This may need to be changed to include project names
-            if (type === "organization") {
-                console.log("Project/Organization Name");
-
-                const organization = element.textContent.trim();
-
+    chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
+        const elements = document.elementsFromPoint(msg.relX, msg.relY);
+        let sentResult = false;
+        for (element of elements) {
+            console.log("looping");
+            if (element.tagName === 'A' && element.querySelector('div')?.textContent.trim() === 'Open') {
+                const numberOpen = element.querySelector('span[aria-hidden="true"]')?.textContent.trim();
+                console.log('Number of Open issues:', numberOpen);
                 sentResult = true;
                 sendResponse({
-                    result: `OrganizationName-${organization}`,
+                    result: `NumIssuesOpen-${numberOpen}`,
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
@@ -62,12 +42,122 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     url: msg.url
                 });
                 return;
-            } else if (type === 'user') {
-                console.log('user link')
-                const user = element.innerHTML;
+            }
+            if (
+                element.tagName === "A" &&
+                element.hasAttribute("data-hovercard-type")
+            ) {
+                const type = element.getAttribute("data-hovercard-type");
+                // This may need to be changed to include project names
+                if (type === "organization") {
+                    console.log("Project/Organization Name");
+
+                    const organization = element.textContent.trim();
+
+                    sentResult = true;
+                    sendResponse({
+                        result: `OrganizationName-${organization}`,
+                        relX: msg.relX,
+                        relY: msg.relY,
+                        time: msg.time,
+                        id: element.id,
+                        url: msg.url
+                    });
+                    return;
+                } else if (type === 'user') {
+                    console.log('user link')
+                    const user = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({
+                        result: `Username-${user}`,
+                        relX: msg.relX,
+                        relY: msg.relY,
+                        time: msg.time,
+                        id: element.id,
+                        url: msg.url
+                    });
+                    return;
+                }
+            }
+
+            if (
+                element.tagName === "A" &&
+                element.getAttribute("data-testid") === "issue-pr-title-link"
+            ) {
+                console.log('issue link')
+                const title = element.textContent.trim();
                 sentResult = true;
                 sendResponse({
-                    result: `Username-${user}`,
+                    result: `Issue-${title}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+
+            if (
+                element.hasAttribute("aria-label")
+            ) {
+                const label = element.getAttribute("aria-label");
+                if (/comment/.test(label)) {
+                    const numberOfComments = element.attributes.getNamedItem('aria-label').value;
+                    sentResult = true;
+                    sendResponse({
+                        result: `NumOfComments-${numberOfComments}`,
+                        relX: msg.relX,
+                        relY: msg.relY,
+                        time: msg.time,
+                        url: msg.url
+                    });
+                    return;
+                }
+            }
+
+            if (
+                element.tagName === "A" &&
+                (
+                    element.href.includes("label%3A") ||
+                    element.href.includes("/labels/")
+                )
+            ) {
+                console.log('Issue label')
+                const labelTitle = element.innerHTML;
+                sentResult = true;
+                sendResponse({
+                    result: `IssueLabel-${labelTitle}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            if (element.tagName === 'RELATIVE-TIME') {
+                console.log('Time open')
+                const opened = element.innerHTML;
+                const timestamp = element.attributes.getNamedItem('title').value;
+                sentResult = true;
+                sendResponse({
+                    result: `IssueOpened-${opened} on ${timestamp}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            if (element.closest('[data-listview-component="trailing-badge"]') &&
+                /\d+\s*\/\s*\d+/.test(element.textContent)) {
+                console.log('Task progress bar')
+                const taskProgress = element.innerHTML;
+                sentResult = true;
+                sendResponse({
+                    result: `TaskCompletion-${taskProgress}`,
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
@@ -77,101 +167,14 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 return;
             }
         }
-
-        if (
-            element.tagName === "A" &&
-            element.getAttribute("data-testid") === "issue-pr-title-link"
-        ) {
-            console.log('issue link')
-            const title = element.textContent.trim();
-            sentResult = true;
+        if (!sentResult) {
             sendResponse({
-                result: `Issue-${title}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-
-        if (
-            element.hasAttribute("aria-label")
-        ) {
-            const label = element.getAttribute("aria-label");
-            if (/comment/.test(label)) {
-                const numberOfComments = element.attributes.getNamedItem('aria-label').value;
-                sentResult = true;
-                sendResponse({
-                    result: `NumOfComments-${numberOfComments}`,
-                    relX: msg.relX,
-                    relY: msg.relY,
+                    result: null,
                     time: msg.time,
-                    url: msg.url
-                });
-                return;
-            }
-        }
-
-        if (
-            element.tagName === "A" &&
-            (
-                element.href.includes("label%3A") ||
-                element.href.includes("/labels/")
+                    relX: msg.relX,
+                    relY: msg.relY
+                }
             )
-        ) {
-            console.log('Issue label')
-            const labelTitle = element.innerHTML;
-            sentResult = true;
-            sendResponse({
-                result: `IssueLabel-${labelTitle}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
         }
-        if (element.tagName === 'RELATIVE-TIME') {
-            console.log('Time open')
-            const opened = element.innerHTML;
-            const timestamp = element.attributes.getNamedItem('title').value;
-            sentResult = true;
-            sendResponse({
-                result: `IssueOpened-${opened} on ${timestamp}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        if (element.closest('[data-listview-component="trailing-badge"]') &&
-            /\d+\s*\/\s*\d+/.test(element.textContent)) {
-            console.log('Task progress bar')
-            const taskProgress = element.innerHTML;
-            sentResult = true;
-            sendResponse({
-                result: `TaskCompletion-${taskProgress}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-    }
-    if (!sentResult) {
-        sendResponse({
-                result: null,
-                time: msg.time,
-                relX: msg.relX,
-                relY: msg.relY
-            }
-        )
-    }
-});
+    });
+}

--- a/Extension Files/assets/js/getGithubPRListCoordinate.js
+++ b/Extension Files/assets/js/getGithubPRListCoordinate.js
@@ -18,53 +18,25 @@
  ************************************************************************************************************************
  ********************************/
 
-
-console.log('Github List of Pull Requests Script Started');
+if (window.iTrace_getGithubPRListCoordinate_Loaded) {
+} else {
+    window.iTrace_getGithubPRListCoordinate_Loaded = true;
+    console.log('Github List of Pull Requests Script Started');
 // looks at list of pull requests and logs its data
-chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
-    try {
-        const relX = msg.relX;
-        const relY = msg.relY;
-        const elements = document.elementsFromPoint(relX, relY) || [];
+    chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
+        try {
+            const relX = msg.relX;
+            const relY = msg.relY;
+            const elements = document.elementsFromPoint(relX, relY) || [];
 
-        for (const element of elements) {
-            if (!element) continue;
+            for (const element of elements) {
+                if (!element) continue;
 
-            // NumPROpen
-            if (element.classList && element.classList.contains('btn-link') && element.innerHTML && element.innerHTML.includes('Open') && element.tagName === 'A') {
-                const numberOpen = element.textContent.trim();
-                sendResponse({
-                    result: `NumPROpen-${numberOpen}`,
-                    relX: relX,
-                    relY: relY,
-                    time: msg.time,
-                    id: element.id || null,
-                    url: msg.url || location.href
-                });
-                return;
-            }
-
-            // NumPRClosed
-            if (element.classList && element.classList.contains('btn-link') && element.innerHTML && element.innerHTML.includes('Closed') && element.tagName === 'A') {
-                const numClosed = element.textContent.trim();
-                sendResponse({
-                    result: `NumPRClosed-${numClosed}`,
-                    relX: relX,
-                    relY: relY,
-                    time: msg.time,
-                    id: element.id || null,
-                    url: msg.url || location.href
-                });
-                return;
-            }
-
-            // Organization (legacy org link)
-            if (element.classList && element.classList.contains('url') && element.classList.contains('fn') && element.tagName === 'A') {
-                const attr = element.getAttribute('data-hovercard-type');
-                if (attr === 'organization') {
-                    const organization = element.textContent.trim();
+                // NumPROpen
+                if (element.classList && element.classList.contains('btn-link') && element.innerHTML && element.innerHTML.includes('Open') && element.tagName === 'A') {
+                    const numberOpen = element.textContent.trim();
                     sendResponse({
-                        result: `Organization - ${organization}`,
+                        result: `NumPROpen-${numberOpen}`,
                         relX: relX,
                         relY: relY,
                         time: msg.time,
@@ -73,15 +45,12 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     });
                     return;
                 }
-            }
 
-            // ProjectName
-            if (element.tagName === 'A') {
-                const projNode = element.closest && element.closest('strong[itemprop="name"]');
-                if (projNode) {
-                    const projectName = element.textContent.trim();
+                // NumPRClosed
+                if (element.classList && element.classList.contains('btn-link') && element.innerHTML && element.innerHTML.includes('Closed') && element.tagName === 'A') {
+                    const numClosed = element.textContent.trim();
                     sendResponse({
-                        result: `ProjectName - ${projectName}`,
+                        result: `NumPRClosed-${numClosed}`,
                         relX: relX,
                         relY: relY,
                         time: msg.time,
@@ -90,50 +59,14 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     });
                     return;
                 }
-            }
 
-            // NumOfStarred
-            if (element.tagName === 'A') {
-                const starCounter = element.querySelector && element.querySelector('#repo-stars-counter-star, .js-social-count, .Counter.js-social-count');
-                if (starCounter) {
-                    const numberStarred = starCounter.textContent.trim();
-                    sendResponse({
-                        result: `NumOfStarred-${numberStarred}`,
-                        relX: relX,
-                        relY: relY,
-                        time: msg.time,
-                        id: starCounter.id || element.id || null,
-                        url: msg.url || location.href
-                    });
-                    return;
-                }
-            }
-
-            // NumOfForked
-            if (element.tagName === 'A') {
-                const forkCounter = element.querySelector && element.querySelector('#repo-network-counter, .Counter, .Counter.js-social-count');
-                if (forkCounter && (forkCounter.id === 'repo-network-counter' || forkCounter.classList.contains('Counter') || forkCounter.classList.contains('js-social-count'))) {
-                    const numberForked = forkCounter.textContent.trim();
-                    sendResponse({
-                        result: `NumOfForked-${numberForked}`,
-                        relX: relX,
-                        relY: relY,
-                        time: msg.time,
-                        id: forkCounter.id || element.id || null,
-                        url: msg.url || location.href
-                    });
-                    return;
-                }
-            }
-
-            // Username
-            if (element.tagName === 'A') {
-                const hoverType = element.getAttribute && element.getAttribute('data-hovercard-type');
-                if (hoverType === 'user') {
-                    const username = element.textContent.trim();
-                    if (username) {
+                // Organization (legacy org link)
+                if (element.classList && element.classList.contains('url') && element.classList.contains('fn') && element.tagName === 'A') {
+                    const attr = element.getAttribute('data-hovercard-type');
+                    if (attr === 'organization') {
+                        const organization = element.textContent.trim();
                         sendResponse({
-                            result: `Username-${username}`,
+                            result: `Organization - ${organization}`,
                             relX: relX,
                             relY: relY,
                             time: msg.time,
@@ -143,123 +76,183 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                         return;
                     }
                 }
-            }
 
-            // PullRequest link
-            if (element.tagName === 'A') {
-                const hover = element.getAttribute && element.getAttribute('data-hovercard-type');
-                if (hover === 'pull_request') {
-                    const title = element.textContent.trim();
-                    const href = element.getAttribute('href') || '';
-                    const m = href.match(/\/pull\/(\d+)(?:\/|$)/);
-                    const prNumber = m ? m[1] : null;
-                    const res = {
-                        result: `PullRequest-${prNumber ? ('#' + prNumber + ' ') : ''}${title}`,
+                // ProjectName
+                if (element.tagName === 'A') {
+                    const projNode = element.closest && element.closest('strong[itemprop="name"]');
+                    if (projNode) {
+                        const projectName = element.textContent.trim();
+                        sendResponse({
+                            result: `ProjectName - ${projectName}`,
+                            relX: relX,
+                            relY: relY,
+                            time: msg.time,
+                            id: element.id || null,
+                            url: msg.url || location.href
+                        });
+                        return;
+                    }
+                }
+
+                // NumOfStarred
+                if (element.tagName === 'A') {
+                    const starCounter = element.querySelector && element.querySelector('#repo-stars-counter-star, .js-social-count, .Counter.js-social-count');
+                    if (starCounter) {
+                        const numberStarred = starCounter.textContent.trim();
+                        sendResponse({
+                            result: `NumOfStarred-${numberStarred}`,
+                            relX: relX,
+                            relY: relY,
+                            time: msg.time,
+                            id: starCounter.id || element.id || null,
+                            url: msg.url || location.href
+                        });
+                        return;
+                    }
+                }
+
+                // NumOfForked
+                if (element.tagName === 'A') {
+                    const forkCounter = element.querySelector && element.querySelector('#repo-network-counter, .Counter, .Counter.js-social-count');
+                    if (forkCounter && (forkCounter.id === 'repo-network-counter' || forkCounter.classList.contains('Counter') || forkCounter.classList.contains('js-social-count'))) {
+                        const numberForked = forkCounter.textContent.trim();
+                        sendResponse({
+                            result: `NumOfForked-${numberForked}`,
+                            relX: relX,
+                            relY: relY,
+                            time: msg.time,
+                            id: forkCounter.id || element.id || null,
+                            url: msg.url || location.href
+                        });
+                        return;
+                    }
+                }
+
+                // Username
+                if (element.tagName === 'A') {
+                    const hoverType = element.getAttribute && element.getAttribute('data-hovercard-type');
+                    if (hoverType === 'user') {
+                        const username = element.textContent.trim();
+                        if (username) {
+                            sendResponse({
+                                result: `Username-${username}`,
+                                relX: relX,
+                                relY: relY,
+                                time: msg.time,
+                                id: element.id || null,
+                                url: msg.url || location.href
+                            });
+                            return;
+                        }
+                    }
+                }
+
+                // PullRequest link
+                if (element.tagName === 'A') {
+                    const hover = element.getAttribute && element.getAttribute('data-hovercard-type');
+                    if (hover === 'pull_request') {
+                        const title = element.textContent.trim();
+                        const href = element.getAttribute('href') || '';
+                        const m = href.match(/\/pull\/(\d+)(?:\/|$)/);
+                        const prNumber = m ? m[1] : null;
+                        const res = {
+                            result: `PullRequest-${prNumber ? ('#' + prNumber + ' ') : ''}${title}`,
+                            relX: relX,
+                            relY: relY,
+                            time: msg.time,
+                            id: element.id || null,
+                            url: msg.url || location.href
+                        };
+                        sendResponse(res);
+                        return;
+                    }
+                }
+
+                // NumOfComments
+                if (element.tagName === 'A') {
+                    const ariaAttr = element.getAttribute && element.getAttribute('aria-label');
+                    if (ariaAttr && ariaAttr.toLowerCase().includes('comment')) {
+                        const numberOfComments = ariaAttr.match(/\d+/)?.[0] || ariaAttr;
+                        sendResponse({
+                            result: `NumOfComments-${numberOfComments}`,
+                            relX: relX,
+                            relY: relY,
+                            time: msg.time,
+                            url: msg.url || location.href
+                        });
+                        return;
+                    }
+                }
+
+                // PR status: review required / approvals / changes requested
+                if (element.tagName === 'A') {
+                    const aria = (element.getAttribute('aria-label') || '').toLowerCase();
+                    if (aria.includes('review required')) {
+                        sendResponse({
+                            result: `PRStatus-Review Required`,
+                            relX: relX,
+                            relY: relY,
+                            time: msg.time,
+                            id: element.id || null,
+                            url: msg.url || location.href
+                        });
+                        return;
+                    }
+                    if (aria.includes('review approval') || aria.includes('review approvals') || /\d+\s+review\s+approvals?/.test(aria)) {
+                        sendResponse({
+                            result: `PRStatus-Approval`,
+                            relX: relX,
+                            relY: relY,
+                            time: msg.time,
+                            id: element.id || null,
+                            url: msg.url || location.href
+                        });
+                        return;
+                    }
+                    if (aria.includes('requesting changes') || aria.includes('changes requested') || aria.includes('request changes')) {
+                        sendResponse({
+                            result: `PRStatus-Changes Requested`,
+                            relX: relX,
+                            relY: relY,
+                            time: msg.time,
+                            id: element.id || null,
+                            url: msg.url || location.href
+                        });
+                        return;
+                    }
+                }
+
+                // Time opened (relative-time element)
+                if (element.tagName === 'RELATIVE-TIME') {
+                    const opened = element.innerHTML;
+                    const timestamp = (element.getAttribute && element.getAttribute('title')) || null;
+                    sendResponse({
+                        result: `PullRequestOpened-${opened}${timestamp ? (' on ' + timestamp) : ''}`,
                         relX: relX,
                         relY: relY,
                         time: msg.time,
                         id: element.id || null,
                         url: msg.url || location.href
-                    };
-                    sendResponse(res);
+                    });
                     return;
                 }
-            }
 
-            // NumOfComments
-            if (element.tagName === 'A') {
-                const ariaAttr = element.getAttribute && element.getAttribute('aria-label');
-                if (ariaAttr && ariaAttr.toLowerCase().includes('comment')) {
-                    const numberOfComments = ariaAttr.match(/\d+/)?.[0] || ariaAttr;
+                // Task progress count
+                if (element.tagName === 'TRACKED-ISSUES-PROGRESS') {
+                    const taskProgress = element.dataset.total;
                     sendResponse({
-                        result: `NumOfComments-${numberOfComments}`,
+                        result: `TaskCompletion-${taskProgress}`,
                         relX: relX,
                         relY: relY,
                         time: msg.time,
+                        id: element.id || null,
                         url: msg.url || location.href
                     });
                     return;
                 }
             }
 
-            // PR status: review required / approvals / changes requested
-            if (element.tagName === 'A') {
-                const aria = (element.getAttribute('aria-label') || '').toLowerCase();
-                if (aria.includes('review required')) {
-                    sendResponse({
-                        result: `PRStatus-Review Required`,
-                        relX: relX,
-                        relY: relY,
-                        time: msg.time,
-                        id: element.id || null,
-                        url: msg.url || location.href
-                    });
-                    return;
-                }
-                if (aria.includes('review approval') || aria.includes('review approvals') || /\d+\s+review\s+approvals?/.test(aria)) {
-                    sendResponse({
-                        result: `PRStatus-Approval`,
-                        relX: relX,
-                        relY: relY,
-                        time: msg.time,
-                        id: element.id || null,
-                        url: msg.url || location.href
-                    });
-                    return;
-                }
-                if (aria.includes('requesting changes') || aria.includes('changes requested') || aria.includes('request changes')) {
-                    sendResponse({
-                        result: `PRStatus-Changes Requested`,
-                        relX: relX,
-                        relY: relY,
-                        time: msg.time,
-                        id: element.id || null,
-                        url: msg.url || location.href
-                    });
-                    return;
-                }
-            }
-
-            // Time opened (relative-time element)
-            if (element.tagName === 'RELATIVE-TIME') {
-                const opened = element.innerHTML;
-                const timestamp = (element.getAttribute && element.getAttribute('title')) || null;
-                sendResponse({
-                    result: `PullRequestOpened-${opened}${timestamp ? (' on ' + timestamp) : ''}`,
-                    relX: relX,
-                    relY: relY,
-                    time: msg.time,
-                    id: element.id || null,
-                    url: msg.url || location.href
-                });
-                return;
-            }
-
-            // Task progress count
-            if (element.tagName === 'TRACKED-ISSUES-PROGRESS') {
-                const taskProgress = element.dataset.total;
-                sendResponse({
-                    result: `TaskCompletion-${taskProgress}`,
-                    relX: relX,
-                    relY: relY,
-                    time: msg.time,
-                    id: element.id || null,
-                    url: msg.url || location.href
-                });
-                return;
-            }
-        }
-
-        // nothing matched
-        sendResponse({
-                result: null,
-                time: msg.time,
-                relX: msg.relX,
-                relY: msg.relY
-            }
-        )
-    } catch (e) {
-        try {
+            // nothing matched
             sendResponse({
                     result: null,
                     time: msg.time,
@@ -267,10 +260,20 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relY: msg.relY
                 }
             )
-        } catch (er) {
+        } catch (e) {
+            try {
+                sendResponse({
+                        result: null,
+                        time: msg.time,
+                        relX: msg.relX,
+                        relY: msg.relY
+                    }
+                )
+            } catch (er) {
+            }
         }
-    }
-});
+    });
+}
 
 /**
  * This page currently logs:

--- a/Extension Files/assets/js/getGithubPullRequestCoordinate.js
+++ b/Extension Files/assets/js/getGithubPullRequestCoordinate.js
@@ -18,124 +18,35 @@
  ************************************************************************************************************************
  ********************************/
 
-
-console.log('Github Pull Requests Script Started');
+if (window.iTrace_getGithubPullRequestCoordinate_Loaded) {
+} else {
+    window.iTrace_getGithubPullRequestCoordinate_Loaded = true;
+    console.log('Github Pull Requests Script Started');
 // looks at a specific pull request and listen/logs the data and things associated with pull requests
-chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
-    const elements = document.elementsFromPoint(msg.relX, msg.relY);
-    let sentResult = false;
-    for (element of elements) {
-        // Words don't appear to work for now.
-        // if (element.id.includes('word')) {
-        //   console.log('word of a comment')
-        //   const word = element.innerHTML.trim();
-        //   sentResult = true;
-        //   if (element.attributes.getNamedItem('listtype')) {
-        //     const listType = element.attributes.getNamedItem('listtype').value === 'ol' ? 'NumberedList' : 'UnorderedList';
-        //     const listNumber = element.attributes.getNamedItem('listnumber').value;
-        //     sendResponse({ result: `CommentWordIn${listType}-${word}-${listNumber}`, relX: msg.relX, relY: msg.relY, time: msg.time, id: element.id, url: msg.url });  
-        //     return;
-        //   } else {
-        //     sendResponse({ result: `CommentWord-${word}`, relX: msg.relX, relY: msg.relY, time: msg.time, id: element.id, url: msg.url });
-        //     return;
-        //   }
-        // }
-        if (element.classList.contains('task-list-item')) {
-            console.log('Checkbox item');
-            sentResult = true;
-            sendResponse({
-                result: `ChecklistItem-`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // if (element.tagName === 'A' && element.classList.contains('participant-avatar')) {
-        //   console.log("participant")
-        //   sentResult = true;
-        //   const user = element.attributes.getNamedItem('data-hovercard-url').value.split('/')[2];
-        //   console.log(user);
-        //   sendResponse({ result: `Participant-${user}`, relX: msg.relX, relY: msg.relY, time: msg.time, id: element.id, url: msg.url });
-        //   return; 
-        // }
-
-        // Number of files changed
-        if (element.attributes.getNamedItem('href')?.value.includes("/files") && element.classList.contains('tabnav-tab')) {
-            console.log('# of files changed');
-            const filesCounter = element.querySelector('#files_tab_counter');
-            const filesCount = filesCounter ? filesCounter.innerHTML.trim() : 'Unknown';
-            sentResult = true;
-            sendResponse({
-                result: `NumOfFilesChanged-${filesCount}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Number of checks
-        if (element.attributes.getNamedItem('href')?.value.includes("/checks") && element.classList.contains('tabnav-tab')) {
-            console.log('# Checks');
-            const checksCounter = element.querySelector('#checks_tab_counter');
-            const checksCount = checksCounter ? checksCounter.innerHTML.trim() : 'Unknown';
-            sentResult = true;
-            sendResponse({
-                result: `NumOfChecks-${checksCount}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Number of commits
-        if (element.attributes.getNamedItem('href')?.value.includes("/commits") && element.classList.contains('tabnav-tab')) {
-            console.log('# Commits');
-            const commitCounter = element.querySelector('#commits_tab_counter');
-            const commitCount = commitCounter ? commitCounter.innerHTML.trim() : 'Unknown';
-            sentResult = true;
-            sendResponse({
-                result: `NumOfCommits-${commitCount}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Number of conversations
-        if (element.attributes.getNamedItem('href')?.value.includes("/pull/") && element.classList.contains('tabnav-tab') &&
-            element.querySelector('#conversation_tab_counter')) {
-            console.log('# Conversations');
-            const conversationCounter = element.querySelector('#conversation_tab_counter');
-            const conversationCount = conversationCounter ? conversationCounter.innerHTML.trim() : 'Unknown';
-            sentResult = true;
-            sendResponse({
-                result: `NumOfConversationComments-${conversationCount}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Number of total diffs
-        if (element.classList.contains('diffstat')) {
-            if (element.id === 'diffstat') {
-                console.log('Number of total diffs');
-                const diffAdd = element.querySelector(".color-fg-success");
-                const diffSub = element.querySelector(".color-fg-danger");
+    chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
+        const elements = document.elementsFromPoint(msg.relX, msg.relY);
+        let sentResult = false;
+        for (element of elements) {
+            // Words don't appear to work for now.
+            // if (element.id.includes('word')) {
+            //   console.log('word of a comment')
+            //   const word = element.innerHTML.trim();
+            //   sentResult = true;
+            //   if (element.attributes.getNamedItem('listtype')) {
+            //     const listType = element.attributes.getNamedItem('listtype').value === 'ol' ? 'NumberedList' : 'UnorderedList';
+            //     const listNumber = element.attributes.getNamedItem('listnumber').value;
+            //     sendResponse({ result: `CommentWordIn${listType}-${word}-${listNumber}`, relX: msg.relX, relY: msg.relY, time: msg.time, id: element.id, url: msg.url });  
+            //     return;
+            //   } else {
+            //     sendResponse({ result: `CommentWord-${word}`, relX: msg.relX, relY: msg.relY, time: msg.time, id: element.id, url: msg.url });
+            //     return;
+            //   }
+            // }
+            if (element.classList.contains('task-list-item')) {
+                console.log('Checkbox item');
                 sentResult = true;
                 sendResponse({
-                    result: `TotalDiffs- ${diffAdd}, ${diffSub}`,
+                    result: `ChecklistItem-`,
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
@@ -144,81 +55,270 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 });
                 return;
             }
-            // Number of file diffs (deprecated)
-            // if (element.classList.contains('tooltipped')) {
-            //   console.log('Number of file diffs');
-            //   const numChanges = element.attributes.getNamedItem('aria-label').value;
+            // if (element.tagName === 'A' && element.classList.contains('participant-avatar')) {
+            //   console.log("participant")
             //   sentResult = true;
-            //   sendResponse({ result: `NumOfFileDiffs-${numChanges.trim()}`, relX: msg.relX, relY: msg.relY, time: msg.time, id: element.id, url: msg.url });
+            //   const user = element.attributes.getNamedItem('data-hovercard-url').value.split('/')[2];
+            //   console.log(user);
+            //   sendResponse({ result: `Participant-${user}`, relX: msg.relX, relY: msg.relY, time: msg.time, id: element.id, url: msg.url });
+            //   return; 
+            // }
+
+            // Number of files changed
+            if (element.attributes.getNamedItem('href')?.value.includes("/files") && element.classList.contains('tabnav-tab')) {
+                console.log('# of files changed');
+                const filesCounter = element.querySelector('#files_tab_counter');
+                const filesCount = filesCounter ? filesCounter.innerHTML.trim() : 'Unknown';
+                sentResult = true;
+                sendResponse({
+                    result: `NumOfFilesChanged-${filesCount}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Number of checks
+            if (element.attributes.getNamedItem('href')?.value.includes("/checks") && element.classList.contains('tabnav-tab')) {
+                console.log('# Checks');
+                const checksCounter = element.querySelector('#checks_tab_counter');
+                const checksCount = checksCounter ? checksCounter.innerHTML.trim() : 'Unknown';
+                sentResult = true;
+                sendResponse({
+                    result: `NumOfChecks-${checksCount}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Number of commits
+            if (element.attributes.getNamedItem('href')?.value.includes("/commits") && element.classList.contains('tabnav-tab')) {
+                console.log('# Commits');
+                const commitCounter = element.querySelector('#commits_tab_counter');
+                const commitCount = commitCounter ? commitCounter.innerHTML.trim() : 'Unknown';
+                sentResult = true;
+                sendResponse({
+                    result: `NumOfCommits-${commitCount}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Number of conversations
+            if (element.attributes.getNamedItem('href')?.value.includes("/pull/") && element.classList.contains('tabnav-tab') &&
+                element.querySelector('#conversation_tab_counter')) {
+                console.log('# Conversations');
+                const conversationCounter = element.querySelector('#conversation_tab_counter');
+                const conversationCount = conversationCounter ? conversationCounter.innerHTML.trim() : 'Unknown';
+                sentResult = true;
+                sendResponse({
+                    result: `NumOfConversationComments-${conversationCount}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Number of total diffs
+            if (element.classList.contains('diffstat')) {
+                if (element.id === 'diffstat') {
+                    console.log('Number of total diffs');
+                    const diffAdd = element.querySelector(".color-fg-success");
+                    const diffSub = element.querySelector(".color-fg-danger");
+                    sentResult = true;
+                    sendResponse({
+                        result: `TotalDiffs- ${diffAdd}, ${diffSub}`,
+                        relX: msg.relX,
+                        relY: msg.relY,
+                        time: msg.time,
+                        id: element.id,
+                        url: msg.url
+                    });
+                    return;
+                }
+                // Number of file diffs (deprecated)
+                // if (element.classList.contains('tooltipped')) {
+                //   console.log('Number of file diffs');
+                //   const numChanges = element.attributes.getNamedItem('aria-label').value;
+                //   sentResult = true;
+                //   sendResponse({ result: `NumOfFileDiffs-${numChanges.trim()}`, relX: msg.relX, relY: msg.relY, time: msg.time, id: element.id, url: msg.url });
+                //   return;
+                // }
+            }
+            // Deleted line of code
+            if (element.tagName === 'TD' && element.classList.contains('blob-code-deletion')) {
+                console.log('Deleted Line of Code');
+                let lineNumber = 0;
+                const lineNumberCell = element.previousElementSibling;
+                if (lineNumberCell && lineNumberCell.hasAttribute('data-line-number')) {
+                    lineNumber = lineNumberCell.getAttribute('data-line-number');
+                }
+                sentResult = true;
+                sendResponse({
+                    result: `DeletedLOC-${lineNumber}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Added line of code
+            if (element.tagName === 'TD' && element.classList.contains('blob-code-addition')) {
+                console.log('Added Line of Code');
+                let lineNumber = 0;
+                const lineNumberCell = element.previousElementSibling;
+                if (lineNumberCell && lineNumberCell.hasAttribute('data-line-number')) {
+                    lineNumber = lineNumberCell.getAttribute('data-line-number');
+                }
+
+                sentResult = true;
+                sendResponse({
+                    result: `AddedLOC-${lineNumber}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            // Unchanged line of code
+            if (element.tagName === 'TD' && element.classList.contains('blob-code-context')) {
+                console.log('Unchanged Line of Code');
+                let lineNumber = 0;
+                const lineNumberCell = element.previousElementSibling;
+                if (lineNumberCell && lineNumberCell.hasAttribute('data-line-number')) {
+                    lineNumber = lineNumberCell.getAttribute('data-line-number');
+                }
+                sendResponse({
+                    result: `UnchangedLOC-${lineNumber}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            if (element.tagName === 'a' && element.attributes.getNamedItem('href')) {
+                // File name
+                if (element.attributes.getNamedItem('href').value.includes("#diff-") && element.classList.contains('text-mono')) {
+                    console.log("Filename")
+                    // const fileName = element.attributes.getNamedItem('title').value;
+                    const fileName = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({
+                        result: `File-${fileName.trim()}`,
+                        relX: msg.relX,
+                        relY: msg.relY,
+                        time: msg.time,
+                        id: element.id,
+                        url: msg.url
+                    });
+                    return;
+                }
+                // Commit name
+                if (element.attributes.getNamedItem('href').value.includes("commits/")) {
+                    console.log("Commit name");
+                    const commitTitle = element.innerHTML;
+                    sentResult = true;
+                    sendResponse({
+                        result: `CommitName-${commitTitle.trim()}`,
+                        relX: msg.relX,
+                        relY: msg.relY,
+                        time: msg.time,
+                        id: element.id,
+                        url: msg.url
+                    });
+                    return;
+                }
+            }
+            if (element.attributes.getNamedItem('data-hovercard-type') && element.attributes.getNamedItem('data-hovercard-type').value === 'user') {
+                console.log('username')
+                let user = element.innerHTML.trim();
+                if (element.tagName === 'SPAN') {
+                    user = element.attributes.getNamedItem('data-assignee-name').value;
+                }
+                sentResult = true;
+                sendResponse({
+                    result: `Username-${user}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+            }
+            if (element.classList.contains('js-issue-title')) {
+                console.log('PR Title');
+                sentResult = true;
+                sendResponse({
+                    result: `PRTitle-${element.innerHTML.trim()}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            if (element.tagName === 'IMG' && element.classList.contains('avatar')) {
+                console.log('User avatar');
+                sentResult = true;
+                const user = element.attributes.getNamedItem('alt') ? element.attributes.getNamedItem('alt').value : '';
+                sendResponse({
+                    result: `AvatarImage-${user}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+
+            // const sidebarElements = ['Reviewers', 'Projects', 'Milestones', 'Labels', 'Assignees'];
+            // if (element.classList.contains('discussion-sidebar-heading') && sidebarElements.includes(element.innerHTML.trim())) {
+            //   console.log(element.innerHTML.trim());
+            //   sentResult = true;
+            //   const header = element.innerHTML.trim();
+            //   sendResponse({ result: `${header}-${header}`, relX: msg.relX, relY: msg.relY, time: msg.time, id: element.id, url: msg.url });
             //   return;
             // }
-        }
-        // Deleted line of code
-        if (element.tagName === 'TD' && element.classList.contains('blob-code-deletion')) {
-            console.log('Deleted Line of Code');
-            let lineNumber = 0;
-            const lineNumberCell = element.previousElementSibling;
-            if (lineNumberCell && lineNumberCell.hasAttribute('data-line-number')) {
-                lineNumber = lineNumberCell.getAttribute('data-line-number');
-            }
-            sentResult = true;
-            sendResponse({
-                result: `DeletedLOC-${lineNumber}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Added line of code
-        if (element.tagName === 'TD' && element.classList.contains('blob-code-addition')) {
-            console.log('Added Line of Code');
-            let lineNumber = 0;
-            const lineNumberCell = element.previousElementSibling;
-            if (lineNumberCell && lineNumberCell.hasAttribute('data-line-number')) {
-                lineNumber = lineNumberCell.getAttribute('data-line-number');
-            }
-
-            sentResult = true;
-            sendResponse({
-                result: `AddedLOC-${lineNumber}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Unchanged line of code
-        if (element.tagName === 'TD' && element.classList.contains('blob-code-context')) {
-            console.log('Unchanged Line of Code');
-            let lineNumber = 0;
-            const lineNumberCell = element.previousElementSibling;
-            if (lineNumberCell && lineNumberCell.hasAttribute('data-line-number')) {
-                lineNumber = lineNumberCell.getAttribute('data-line-number');
-            }
-            sendResponse({
-                result: `UnchangedLOC-${lineNumber}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        if (element.tagName === 'a' && element.attributes.getNamedItem('href')) {
-            // File name
-            if (element.attributes.getNamedItem('href').value.includes("#diff-") && element.classList.contains('text-mono')) {
-                console.log("Filename")
-                // const fileName = element.attributes.getNamedItem('title').value;
-                const fileName = element.innerHTML;
+            if (element.tagName === 'FORM' && element.classList.contains('js-issue-sidebar-form')) {
+                let ariaLabel = element.getAttribute('aria-label') || 'UnknownForm';
+                ariaLabel = ariaLabel.replace(/^Select\s+/i, '')
+                if (ariaLabel === "Link issues") {
+                    ariaLabel = "development"
+                }
+                console.log(`Sidebar - ${ariaLabel}`);
                 sentResult = true;
                 sendResponse({
-                    result: `File-${fileName.trim()}`,
+                    result: `Sidebar-${ariaLabel}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: element.id,
+                    url: msg.url
+                });
+            }
+            if (element.classList.contains('participation')) {
+                console.log("Sidebar - Participation")
+                sentResult = true;
+                sendResponse({
+                    result: `Sidebar-Participation`,
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
@@ -227,13 +327,12 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 });
                 return;
             }
-            // Commit name
-            if (element.attributes.getNamedItem('href').value.includes("commits/")) {
-                console.log("Commit name");
-                const commitTitle = element.innerHTML;
+            if (element.classList.contains('IssueLabel')) {
+                console.log("Issue Label");
                 sentResult = true;
+                const labelName = element.firstChild.nextSibling ? element.firstChild.nextSibling.innerHTML : '';
                 sendResponse({
-                    result: `CommitName-${commitTitle.trim()}`,
+                    result: `IssueLabel-${labelName}`,
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
@@ -242,172 +341,11 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 });
                 return;
             }
-        }
-        if (element.attributes.getNamedItem('data-hovercard-type') && element.attributes.getNamedItem('data-hovercard-type').value === 'user') {
-            console.log('username')
-            let user = element.innerHTML.trim();
-            if (element.tagName === 'SPAN') {
-                user = element.attributes.getNamedItem('data-assignee-name').value;
-            }
-            sentResult = true;
-            sendResponse({
-                result: `Username-${user}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-        }
-        if (element.classList.contains('js-issue-title')) {
-            console.log('PR Title');
-            sentResult = true;
-            sendResponse({
-                result: `PRTitle-${element.innerHTML.trim()}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        if (element.tagName === 'IMG' && element.classList.contains('avatar')) {
-            console.log('User avatar');
-            sentResult = true;
-            const user = element.attributes.getNamedItem('alt') ? element.attributes.getNamedItem('alt').value : '';
-            sendResponse({
-                result: `AvatarImage-${user}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-
-        // const sidebarElements = ['Reviewers', 'Projects', 'Milestones', 'Labels', 'Assignees'];
-        // if (element.classList.contains('discussion-sidebar-heading') && sidebarElements.includes(element.innerHTML.trim())) {
-        //   console.log(element.innerHTML.trim());
-        //   sentResult = true;
-        //   const header = element.innerHTML.trim();
-        //   sendResponse({ result: `${header}-${header}`, relX: msg.relX, relY: msg.relY, time: msg.time, id: element.id, url: msg.url });
-        //   return;
-        // }
-        if (element.tagName === 'FORM' && element.classList.contains('js-issue-sidebar-form')) {
-            let ariaLabel = element.getAttribute('aria-label') || 'UnknownForm';
-            ariaLabel = ariaLabel.replace(/^Select\s+/i, '')
-            if (ariaLabel === "Link issues") {
-                ariaLabel = "development"
-            }
-            console.log(`Sidebar - ${ariaLabel}`);
-            sentResult = true;
-            sendResponse({
-                result: `Sidebar-${ariaLabel}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-        }
-        if (element.classList.contains('participation')) {
-            console.log("Sidebar - Participation")
-            sentResult = true;
-            sendResponse({
-                result: `Sidebar-Participation`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        if (element.classList.contains('IssueLabel')) {
-            console.log("Issue Label");
-            sentResult = true;
-            const labelName = element.firstChild.nextSibling ? element.firstChild.nextSibling.innerHTML : '';
-            sendResponse({
-                result: `IssueLabel-${labelName}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        if (element.tagName === 'RELATIVE-TIME') {
-            console.log("Time");
-            sentResult = true;
-            sendResponse({
-                result: `CommentDate-${element.innerHTML}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Image within comment body
-        if (element.tagName === 'IMG' && (element.parentNode.parentNode.parentNode.classList.contains('comment-body') ||
-            element.parentNode.parentNode.parentNode.parentNode.classList.contains('comment-body'))) {
-            console.log("Image");
-            sentResult = true;
-            const imgUrl = element.parentNode.attributes.getNamedItem('href') ? element.parentNode.attributes.getNamedItem('href').value : '';
-            sendResponse({
-                result: `Image-${imgUrl}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Comment body
-        if ((element.tagName === 'TD' || element.tagName === 'DIV') && element.classList.contains('comment-body')) {
-            console.log('Comment body');
-            sentResult = true;
-            const timelineBody = element.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode;
-            const commentID = timelineBody.attributes.getNamedItem('id') ? timelineBody.attributes.getNamedItem('id').value : '';
-            sendResponse({
-                result: `Comment Body-${commentID}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Comment body within discussion
-        if (element.classList.contains('width-auto') && element.classList.contains('comment-body')) {
-            console.log('Comment body - Discussion');
-            sentResult = true;
-            const timelineBody = element.parentNode.parentNode.parentNode.parentNode.parentNode;
-            const commentID = timelineBody.attributes.getNamedItem('id') ? timelineBody.attributes.getNamedItem('id').value : '';
-            sendResponse({
-                result: `Comment Body-${commentID}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        if (element.tagName === 'IMG' && element.classList.contains('avatar')) {
-            // Avatar in Timeline
-            if (element.parentNode.parentNode.classList.contains('TimelineItem')) {
-                console.log('User avatar - Timeline Item');
+            if (element.tagName === 'RELATIVE-TIME') {
+                console.log("Time");
                 sentResult = true;
-                const user = element.attributes.getNamedItem('alt') ? element.attributes.getNamedItem('alt').value : '';
                 sendResponse({
-                    result: `TimelineAvatarImage-${user}`,
+                    result: `CommentDate-${element.innerHTML}`,
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
@@ -416,13 +354,14 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 });
                 return;
             }
-            // Avatar in Comment Header
-            if (element.classList.contains('rounded-1')) {
-                console.log('User avatar - Comment header');
+            // Image within comment body
+            if (element.tagName === 'IMG' && (element.parentNode.parentNode.parentNode.classList.contains('comment-body') ||
+                element.parentNode.parentNode.parentNode.parentNode.classList.contains('comment-body'))) {
+                console.log("Image");
                 sentResult = true;
-                const user = element.attributes.getNamedItem('alt') ? element.attributes.getNamedItem('alt').value : '';
+                const imgUrl = element.parentNode.attributes.getNamedItem('href') ? element.parentNode.attributes.getNamedItem('href').value : '';
                 sendResponse({
-                    result: `HeaderAvatarImage-${user}`,
+                    result: `Image-${imgUrl}`,
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
@@ -431,13 +370,14 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 });
                 return;
             }
-            // Avatar in Code Review Comment
-            if (element.parentNode.parentNode.classList.contains('mt-1') || element.parentNode.parentNode.classList.contains('mr-2')) {
-                console.log('User avatar - Code Review Comment');
+            // Comment body
+            if ((element.tagName === 'TD' || element.tagName === 'DIV') && element.classList.contains('comment-body')) {
+                console.log('Comment body');
                 sentResult = true;
-                const user = element.attributes.getNamedItem('alt') ? element.attributes.getNamedItem('alt').value : '';
+                const timelineBody = element.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode;
+                const commentID = timelineBody.attributes.getNamedItem('id') ? timelineBody.attributes.getNamedItem('id').value : '';
                 sendResponse({
-                    result: `HeaderAvatarImage-${user}`,
+                    result: `Comment Body-${commentID}`,
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
@@ -446,13 +386,14 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 });
                 return;
             }
-            // Avatar in Sidebar - Participants
-            if (element.parentNode.classList.contains('participant-avatar')) {
-                console.log('User avatar - Participant');
+            // Comment body within discussion
+            if (element.classList.contains('width-auto') && element.classList.contains('comment-body')) {
+                console.log('Comment body - Discussion');
                 sentResult = true;
-                const user = element.attributes.getNamedItem('alt') ? element.attributes.getNamedItem('alt').value : '';
+                const timelineBody = element.parentNode.parentNode.parentNode.parentNode.parentNode;
+                const commentID = timelineBody.attributes.getNamedItem('id') ? timelineBody.attributes.getNamedItem('id').value : '';
                 sendResponse({
-                    result: `ParticipantAvatarImage-${user}`,
+                    result: `Comment Body-${commentID}`,
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
@@ -461,30 +402,92 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 });
                 return;
             }
-            // Avatar in Sidebar - Reviewers
-            else {
-                console.log('User avatar - Reviewers');
-                sentResult = true;
-                const user = element.attributes.getNamedItem('alt') ? element.attributes.getNamedItem('alt').value : '';
-                sendResponse({
-                    result: `ReviewerAvatarImage-${user}`,
-                    relX: msg.relX,
-                    relY: msg.relY,
-                    time: msg.time,
-                    id: element.id,
-                    url: msg.url
-                });
-                return;
+            if (element.tagName === 'IMG' && element.classList.contains('avatar')) {
+                // Avatar in Timeline
+                if (element.parentNode.parentNode.classList.contains('TimelineItem')) {
+                    console.log('User avatar - Timeline Item');
+                    sentResult = true;
+                    const user = element.attributes.getNamedItem('alt') ? element.attributes.getNamedItem('alt').value : '';
+                    sendResponse({
+                        result: `TimelineAvatarImage-${user}`,
+                        relX: msg.relX,
+                        relY: msg.relY,
+                        time: msg.time,
+                        id: element.id,
+                        url: msg.url
+                    });
+                    return;
+                }
+                // Avatar in Comment Header
+                if (element.classList.contains('rounded-1')) {
+                    console.log('User avatar - Comment header');
+                    sentResult = true;
+                    const user = element.attributes.getNamedItem('alt') ? element.attributes.getNamedItem('alt').value : '';
+                    sendResponse({
+                        result: `HeaderAvatarImage-${user}`,
+                        relX: msg.relX,
+                        relY: msg.relY,
+                        time: msg.time,
+                        id: element.id,
+                        url: msg.url
+                    });
+                    return;
+                }
+                // Avatar in Code Review Comment
+                if (element.parentNode.parentNode.classList.contains('mt-1') || element.parentNode.parentNode.classList.contains('mr-2')) {
+                    console.log('User avatar - Code Review Comment');
+                    sentResult = true;
+                    const user = element.attributes.getNamedItem('alt') ? element.attributes.getNamedItem('alt').value : '';
+                    sendResponse({
+                        result: `HeaderAvatarImage-${user}`,
+                        relX: msg.relX,
+                        relY: msg.relY,
+                        time: msg.time,
+                        id: element.id,
+                        url: msg.url
+                    });
+                    return;
+                }
+                // Avatar in Sidebar - Participants
+                if (element.parentNode.classList.contains('participant-avatar')) {
+                    console.log('User avatar - Participant');
+                    sentResult = true;
+                    const user = element.attributes.getNamedItem('alt') ? element.attributes.getNamedItem('alt').value : '';
+                    sendResponse({
+                        result: `ParticipantAvatarImage-${user}`,
+                        relX: msg.relX,
+                        relY: msg.relY,
+                        time: msg.time,
+                        id: element.id,
+                        url: msg.url
+                    });
+                    return;
+                }
+                // Avatar in Sidebar - Reviewers
+                else {
+                    console.log('User avatar - Reviewers');
+                    sentResult = true;
+                    const user = element.attributes.getNamedItem('alt') ? element.attributes.getNamedItem('alt').value : '';
+                    sendResponse({
+                        result: `ReviewerAvatarImage-${user}`,
+                        relX: msg.relX,
+                        relY: msg.relY,
+                        time: msg.time,
+                        id: element.id,
+                        url: msg.url
+                    });
+                    return;
+                }
             }
         }
-    }
-    if (!sentResult) {
-        sendResponse({
-                result: null,
-                time: msg.time,
-                relX: msg.relX,
-                relY: msg.relY
-            }
-        )
-    }
-});
+        if (!sentResult) {
+            sendResponse({
+                    result: null,
+                    time: msg.time,
+                    relX: msg.relX,
+                    relY: msg.relY
+                }
+            )
+        }
+    });
+}

--- a/Extension Files/assets/js/getGoogleCoordinate.js
+++ b/Extension Files/assets/js/getGoogleCoordinate.js
@@ -17,67 +17,70 @@
  * https://www.gnu.org/licenses/.
  ************************************************************************************************************************
  ********************************/
-
-console.log('Get Google Coordinates Script Started');
+if (window.iTrace_getGoogleCoordinate_Loaded) {
+} else {
+    window.iTrace_getGoogleCoordinate_Loaded = true;
+    console.log('Get Google Coordinates Script Started');
 
 // listens and logs for google's data
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-    console.log("[ContentScript] Message received:", msg);
+    chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+        console.log("[ContentScript] Message received:", msg);
 
-    if (!msg || !msg.text) {
-        console.warn("[ContentScript] Invalid message", msg);
-        sendResponse({error: "Invalid message"});
+        if (!msg || !msg.text) {
+            console.warn("[ContentScript] Invalid message", msg);
+            sendResponse({error: "Invalid message"});
+            return true;
+        }
+
+        const elements = document.elementsFromPoint(msg.relX, msg.relY);
+        console.log("[ContentScript] Found", elements.length, "elements at point", msg.relX, msg.relY);
+
+        let responseData = null;
+
+        for (const element of elements) {
+            console.log("Element: ", element);
+            if (element.classList.contains('yuRUbf')) {
+                console.log('[ContentScript] Matched search title');
+                responseData = {
+                    result: 'search title',
+                    word: element.textContent,
+                    url: msg.url,
+                    time: msg.time,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    tagname: element.tagName,
+                };
+                break;
+            }
+            if (element.classList.contains('VwiC3b')) {
+                console.log('[ContentScript] Matched search description');
+                responseData = {
+                    result: 'search description',
+                    word: element.textContent,
+                    url: msg.url,
+                    time: msg.time,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    tagname: element.tagName,
+                };
+                break;
+            }
+        }
+
+        if (!responseData) {
+            console.log("[ContentScript] No matching element found");
+            responseData = {
+                result: null,
+                time: msg.time,
+                relX: msg.relX,
+                relY: msg.relY
+            };
+        }
+
+        console.log("[ContentScript] Sending response:", responseData);
+        sendResponse(responseData);
         return true;
-    }
-
-    const elements = document.elementsFromPoint(msg.relX, msg.relY);
-    console.log("[ContentScript] Found", elements.length, "elements at point", msg.relX, msg.relY);
-
-    let responseData = null;
-
-    for (const element of elements) {
-        console.log("Element: ", element);
-        if (element.classList.contains('yuRUbf')) {
-            console.log('[ContentScript] Matched search title');
-            responseData = {
-                result: 'search title',
-                word: element.textContent,
-                url: msg.url,
-                time: msg.time,
-                relX: msg.relX,
-                relY: msg.relY,
-                tagname: element.tagName,
-            };
-            break;
-        }
-        if (element.classList.contains('VwiC3b')) {
-            console.log('[ContentScript] Matched search description');
-            responseData = {
-                result: 'search description',
-                word: element.textContent,
-                url: msg.url,
-                time: msg.time,
-                relX: msg.relX,
-                relY: msg.relY,
-                tagname: element.tagName,
-            };
-            break;
-        }
-    }
-
-    if (!responseData) {
-        console.log("[ContentScript] No matching element found");
-        responseData = {
-            result: null,
-            time: msg.time,
-            relX: msg.relX,
-            relY: msg.relY
-        };
-    }
-
-    console.log("[ContentScript] Sending response:", responseData);
-    sendResponse(responseData);
-    return true;
-});
+    });
+}
 
 

--- a/Extension Files/assets/js/getSOCoordinate.js
+++ b/Extension Files/assets/js/getSOCoordinate.js
@@ -20,40 +20,26 @@
 
 // Listen for messages, (stackoverflow) currently listens for code, images, the post's text
 // the post's tags, and the question itself, it also logs and sends a response based on the result/data
+if (window.iTrace_getSOCoordinate_Loaded) {
+} else {
+    window.iTrace_getSOCoordinate_Loaded = true;
+    console.log('Get SO Questions Coordinates Script Started');
 
-console.log('Get SO Questions Coordinates Script Started');
+    chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
+        var questionElement = document.getElementById('question');
+        var answerElements = document.getElementById('answers').children;
+        var elements = document.elementsFromPoint(msg.relX, msg.relY);
 
-chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
-    var questionElement = document.getElementById('question');
-    var answerElements = document.getElementById('answers').children;
-    var elements = document.elementsFromPoint(msg.relX, msg.relY);
-
-    var sentResult = false;
-    for (element of elements) {
-        if (element) {
-            if (element.tagName == 'CODE') {
-                if (questionElement.contains(element)) {
-                    // question code
-                    console.log('question code');
-                    sentResult = true;
-                    sendResponse({
-                        result: 'question code',
-                        relX: msg.relX,
-                        relY: msg.relY,
-                        time: msg.time,
-                        tagname: element.tagName,
-                        id: element.id,
-                        url: msg.url
-                    });
-                    return;
-                }
-                for (answer of answerElements) {
-                    if (answer.contains(element)) {
-                        // answer code
-                        console.log('answer code');
+        var sentResult = false;
+        for (element of elements) {
+            if (element) {
+                if (element.tagName == 'CODE') {
+                    if (questionElement.contains(element)) {
+                        // question code
+                        console.log('question code');
                         sentResult = true;
                         sendResponse({
-                            result: 'answer code',
+                            result: 'question code',
                             relX: msg.relX,
                             relY: msg.relY,
                             time: msg.time,
@@ -63,32 +49,32 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                         });
                         return;
                     }
+                    for (answer of answerElements) {
+                        if (answer.contains(element)) {
+                            // answer code
+                            console.log('answer code');
+                            sentResult = true;
+                            sendResponse({
+                                result: 'answer code',
+                                relX: msg.relX,
+                                relY: msg.relY,
+                                time: msg.time,
+                                tagname: element.tagName,
+                                id: element.id,
+                                url: msg.url
+                            });
+                            return;
+                        }
+                    }
                 }
-            }
 
-            if (element.tagName == 'IMG') {
-                if (questionElement.contains(element)) {
-                    // question code
-                    console.log('question image');
-                    sentResult = true;
-                    sendResponse({
-                        result: 'question image',
-                        relX: msg.relX,
-                        relY: msg.relY,
-                        time: msg.time,
-                        tagname: element.tagName,
-                        id: element.id,
-                        url: msg.url
-                    });
-                    return;
-                }
-                for (answer of answerElements) {
-                    if (answer.contains(element)) {
-                        // answer code
-                        console.log('answer image');
+                if (element.tagName == 'IMG') {
+                    if (questionElement.contains(element)) {
+                        // question code
+                        console.log('question image');
                         sentResult = true;
                         sendResponse({
-                            result: 'answer image',
+                            result: 'question image',
                             relX: msg.relX,
                             relY: msg.relY,
                             time: msg.time,
@@ -98,33 +84,33 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                         });
                         return;
                     }
+                    for (answer of answerElements) {
+                        if (answer.contains(element)) {
+                            // answer code
+                            console.log('answer image');
+                            sentResult = true;
+                            sendResponse({
+                                result: 'answer image',
+                                relX: msg.relX,
+                                relY: msg.relY,
+                                time: msg.time,
+                                tagname: element.tagName,
+                                id: element.id,
+                                url: msg.url
+                            });
+                            return;
+                        }
+                    }
                 }
-            }
 
-            if (element.classList.contains('js-post-body') ||
-                element.classList.contains('s-prose')) {
-                if (questionElement.contains(element)) {
-                    // question code
-                    console.log('question text');
-                    sentResult = true;
-                    sendResponse({
-                        result: 'question text',
-                        relX: msg.relX,
-                        relY: msg.relY,
-                        time: msg.time,
-                        tagname: element.tagName,
-                        id: element.id,
-                        url: msg.url
-                    });
-                    return;
-                }
-                for (answer of answerElements) {
-                    if (answer.contains(element)) {
-                        // answer code
-                        console.log('answer text');
+                if (element.classList.contains('js-post-body') ||
+                    element.classList.contains('s-prose')) {
+                    if (questionElement.contains(element)) {
+                        // question code
+                        console.log('question text');
                         sentResult = true;
                         sendResponse({
-                            result: 'answer text',
+                            result: 'question text',
                             relX: msg.relX,
                             relY: msg.relY,
                             time: msg.time,
@@ -134,31 +120,30 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                         });
                         return;
                     }
+                    for (answer of answerElements) {
+                        if (answer.contains(element)) {
+                            // answer code
+                            console.log('answer text');
+                            sentResult = true;
+                            sendResponse({
+                                result: 'answer text',
+                                relX: msg.relX,
+                                relY: msg.relY,
+                                time: msg.time,
+                                tagname: element.tagName,
+                                id: element.id,
+                                url: msg.url
+                            });
+                            return;
+                        }
+                    }
                 }
-            }
 
-            if (element.classList.contains('post-tag')) {
-                console.log('question-tag');
-                sentResult = true;
-                sendResponse({
-                    result: 'question tag',
-                    relX: msg.relX,
-                    relY: msg.relY,
-                    time: msg.time,
-                    tagname: element.tagName,
-                    id: element.id,
-                    url: msg.url
-                });
-                return;
-            }
-
-            if (element.closest('.js-voting-container')) {
-                if (questionElement.contains(element)) {
-                    // question code
-                    console.log('question vote');
+                if (element.classList.contains('post-tag')) {
+                    console.log('question-tag');
                     sentResult = true;
                     sendResponse({
-                        result: 'question vote',
+                        result: 'question tag',
                         relX: msg.relX,
                         relY: msg.relY,
                         time: msg.time,
@@ -168,13 +153,14 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     });
                     return;
                 }
-                for (answer of answerElements) {
-                    if (answer.contains(element)) {
-                        // answer code
-                        console.log('answer vote');
+
+                if (element.closest('.js-voting-container')) {
+                    if (questionElement.contains(element)) {
+                        // question code
+                        console.log('question vote');
                         sentResult = true;
                         sendResponse({
-                            result: 'answer vote',
+                            result: 'question vote',
                             relX: msg.relX,
                             relY: msg.relY,
                             time: msg.time,
@@ -184,32 +170,49 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                         });
                         return;
                     }
+                    for (answer of answerElements) {
+                        if (answer.contains(element)) {
+                            // answer code
+                            console.log('answer vote');
+                            sentResult = true;
+                            sendResponse({
+                                result: 'answer vote',
+                                relX: msg.relX,
+                                relY: msg.relY,
+                                time: msg.time,
+                                tagname: element.tagName,
+                                id: element.id,
+                                url: msg.url
+                            });
+                            return;
+                        }
+                    }
                 }
-            }
 
-            if (element.closest('#question-header')) {
-                console.log('question-title');
-                sentResult = true;
-                sendResponse({
-                    result: 'question-title',
-                    relX: msg.relX,
-                    relY: msg.relY,
-                    time: msg.time,
-                    tagname: element.tagName,
-                    id: element.id,
-                    url: msg.url
-                });
-                return;
+                if (element.closest('#question-header')) {
+                    console.log('question-title');
+                    sentResult = true;
+                    sendResponse({
+                        result: 'question-title',
+                        relX: msg.relX,
+                        relY: msg.relY,
+                        time: msg.time,
+                        tagname: element.tagName,
+                        id: element.id,
+                        url: msg.url
+                    });
+                    return;
+                }
             }
         }
-    }
 
-    if (!sentResult) {
-        sendResponse({
-            result: null,
-            time: msg.time,
-            relX: msg.relX,
-            relY: msg.relY
-        })
-    }
-});
+        if (!sentResult) {
+            sendResponse({
+                result: null,
+                time: msg.time,
+                relX: msg.relX,
+                relY: msg.relY
+            })
+        }
+    });
+}

--- a/Extension Files/assets/js/getSearchCoordinate.js
+++ b/Extension Files/assets/js/getSearchCoordinate.js
@@ -20,76 +20,79 @@
 
 // Listen for messages - logs and sends response based on search result, currently listesn for a question and its summary,
 // a vote and its count, and a summary
+if (window.iTrace_getSearchCoordinate_Loaded) {
+} else {
+    window.iTrace_getSearchCoordinate_Loaded = true;
+    console.log('Get SO Search Coordinates Script Started');
 
-console.log('Get SO Search Coordinates Script Started');
+    chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
+        var elements = document.elementsFromPoint(msg.relX, msg.relY);
 
-chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
-    var elements = document.elementsFromPoint(msg.relX, msg.relY);
-
-    var fixationElement = document.getElementById('fixationMover');
-    if (fixationElement == null) {
-        fixationElement = document.createElement("DIV");
-        fixationElement.setAttribute('id', 'fixationMover');
-        fixationElement.setAttribute('style', 'border-radius:100%;border:5px red solid;height:30px;width:30px;position:fixed');
-        document.body.appendChild(fixationElement);
-    }
-
-    fixationElement.style.left = msg.relX + "px";
-    fixationElement.style.top = msg.relY + "px";
-
-    var sentResult = false;
-    // console.log('Hello');
-    for (element of elements) {
-        if (element.classList.contains('answer-hyperlink')) {
-            console.log('answer-hyperlink');
-            sentResult = true;
-            sendResponse({
-                result: 'answer-hyperlink',
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                tagname: element.tagName,
-                id: element.id,
-                url: msg.url
-            });
-            return;
+        var fixationElement = document.getElementById('fixationMover');
+        if (fixationElement == null) {
+            fixationElement = document.createElement("DIV");
+            fixationElement.setAttribute('id', 'fixationMover');
+            fixationElement.setAttribute('style', 'border-radius:100%;border:5px red solid;height:30px;width:30px;position:fixed');
+            document.body.appendChild(fixationElement);
         }
-        if (element.classList.contains('s-post-summary--stats-item-number')) {
-            console.log('question-vote count');
-            sentResult = true;
-            sendResponse({
-                result: 'question vote count',
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                tagname: element.tagName,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        if (element.classList.contains('s-post-summary--content-excerpt')) {
-            console.log('summary');
-            sentResult = true;
-            sendResponse({
-                result: 'summary',
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                tagname: element.tagName,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-    }
 
-    if (!sentResult) {
-        sendResponse({
-            result: null,
-            time: msg.time,
-            relX: msg.relX,
-            relY: msg.relY
-        })
-    }
-});
+        fixationElement.style.left = msg.relX + "px";
+        fixationElement.style.top = msg.relY + "px";
+
+        var sentResult = false;
+        // console.log('Hello');
+        for (element of elements) {
+            if (element.classList.contains('answer-hyperlink')) {
+                console.log('answer-hyperlink');
+                sentResult = true;
+                sendResponse({
+                    result: 'answer-hyperlink',
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    tagname: element.tagName,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            if (element.classList.contains('s-post-summary--stats-item-number')) {
+                console.log('question-vote count');
+                sentResult = true;
+                sendResponse({
+                    result: 'question vote count',
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    tagname: element.tagName,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+            if (element.classList.contains('s-post-summary--content-excerpt')) {
+                console.log('summary');
+                sentResult = true;
+                sendResponse({
+                    result: 'summary',
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    tagname: element.tagName,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
+            }
+        }
+
+        if (!sentResult) {
+            sendResponse({
+                result: null,
+                time: msg.time,
+                relX: msg.relX,
+                relY: msg.relY
+            })
+        }
+    });
+}

--- a/Extension Files/manifest.json
+++ b/Extension Files/manifest.json
@@ -85,6 +85,7 @@
     "default_popup": "popup.html"
   },
   "permissions": [
+    "webNavigation",
     "storage",
     "scripting",
     "tabs",

--- a/Extension Files/manifest.json
+++ b/Extension Files/manifest.json
@@ -93,7 +93,14 @@
     "downloads"
   ],
   "host_permissions": [
-    "https://*.google.com/*"
+    "https://*.google.com/*",
+    "https://github.com/*",
+    "https://stackoverflow.com/*",
+    "*://bugzilla-dev.allizom.org/*",
+    "*://bugs.eclipse.org/*",
+    "*://bugzilla.mozilla.org/*",
+    "*://bugzilla.kernel.org/*",
+    "*://bz.apache.org/*"
   ],
   "externally_connectable": {
     "matches": [


### PR DESCRIPTION
This PR adds several content script injectors to the service worker. This assures that that the user will not need to refresh the page in order to re-inject the content script. Additional changes were made to each content script to assure that they aren't injected into a single web-page multiple times.

Changes:

- Re-injection guards put in place in each content script.
- New Chrome Listeners added to re-inject upon navigation or update of the current page.
- New Extension startup step to re-inject content scripts to all active pages, so that the user doesn't have to refresh each page when the extension falls asleep or restarts the extension.