### PR TITLE
27 xml descriptors

### DIFF
--- a/Extension Files/assets/js/getBZCoordinate.js
+++ b/Extension Files/assets/js/getBZCoordinate.js
@@ -26,7 +26,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
 
     var sentResult = false;
     for (element of elements) {
-        if (element.classList.contains('module-categories')) {
+        if (element.id === 'module-categories') {
             console.log('question info - categories');
             sentResult = true;
             sendResponse({
@@ -56,11 +56,11 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
             return;
         }
 
-        if (element.classList.contains('comment-text')) {
-            console.log('answer info');
+        if (element.id === 'module-attachments') {
+            console.log('attachment info');
             sentResult = true;
             sendResponse({
-                result: 'answer info',
+                result: 'attachment info',
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
@@ -71,11 +71,11 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
             return;
         }
 
-        if (element.tagName == 'TR') {
-            console.log('attachment info');
+        if (element.classList.contains('comment-text')) {
+            console.log('answer info');
             sentResult = true;
             sendResponse({
-                result: 'attachment info',
+                result: 'answer info',
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,

--- a/Extension Files/assets/js/getGithubDevProfileCoordinate.js
+++ b/Extension Files/assets/js/getGithubDevProfileCoordinate.js
@@ -37,30 +37,13 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
             return;
         }
-        // Activity overview (deprecated?)
-        if (element.classList.contains("js-activity-overview-graph-container") && element.attributes.getNamedItem('data-percentages')) {
-            console.log("Activity Overview");
-            let activityOverview = element.attributes.getNamedItem('data-percentages').value;
-            activityOverview = JSON.parse(activityOverview);
-            const percentCommits = activityOverview["Commits"];
-            const percentCodeReview = activityOverview["Code review"];
-            const percentPullRequests = activityOverview["Pull requests"];
-            sentResult = true;
-            sendResponse({
-                result: `ActivityOverview-Commit:${percentCommits}%,CodeReview:${percentCodeReview}%,PullRequest:${percentPullRequests}%`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
+
         // Contribution heat map
         if (element.tagName === 'DIV' && element.classList.contains("graph-before-activity-overview")) {
             console.log('Contribution Heat Map')
@@ -70,6 +53,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -85,6 +69,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -100,6 +85,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -115,6 +101,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -134,6 +121,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -148,6 +136,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -162,6 +151,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -176,6 +166,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -184,7 +175,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         // Organization icon and link
         // if (element.tagName === 'A' && element.attributes.getNamedItem("data-hovercard-type") && element.attributes.getNamedItem("data-hovercard-type").value === "organization"
         // && element.classList.contains("avatar-group-item")) {
-        if (element.classList.contains("pt-3") && element.classList.contains("clearfix")) {
+        if (element.classList.contains("tmp-pt-3") && element.classList.contains("clearfix")) {
             console.log('Organizations Section');
             // const organizationName = element.attributes.getNamedItem("aria-label").value;
             sentResult = true;
@@ -193,21 +184,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Contributed repository link (deprecated?)
-        if (element.tagName === 'A' && element.attributes.getNamedItem("itemprop") && element.attributes.getNamedItem("itemprop").value.includes("codeRepository")) {
-            console.log('Contributed repositories')
-            const repoName = element.innerHTML;
-            sentResult = true;
-            sendResponse({
-                result: `Repository-${repoName}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -233,29 +210,38 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
             return;
         }
         // tab and counter
-        if (element.classList.contains("Counter")) {
-            console.log("Tab Counter")
-            const tab = element.parentElement.innerHTML;
-            const number = element.innerHTML
-            sentResult = true;
+        if (element.dataset.component === "counter") {
+            const tabElement = element.closest("a");
+            const tabName =
+                tabElement?.querySelector('[data-component="text"]')
+                    ?.textContent.trim() || "";
+
+            const number =
+                element.querySelector(".prc-CounterLabel-CounterLabel-X-kRU")
+                    ?.textContent.trim() || "";
+
+            console.log(`Tab Counter: ${tabName} (${number})`);
+
             sendResponse({
-                result: `Num${tab}-${number}`,
+                result: `Num${tabName}-${number}`,
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
             return;
         }
         // tab but no counter
-        if (element.classList.contains("UnderlineNav-item")) {
+        if (element.classList.contains("prc-UnderlineNav-UnderlineNavItem-syRjR")) {
             const tabName = element.innerText.replace(/\s+/g, ' ').trim(); // clean up whitespace
             console.log(`Tab (no counter) ${tabName}`)
             sentResult = true;
@@ -264,6 +250,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -272,18 +259,25 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         // Contribution activity entry
         if (element.classList.contains("TimelineItem")) {
             console.log("Contribution Activity Entry");
-            const summary = element.querySelector("h4 span.color-fg-default");
-            activityText = summary ? summary.textContent.trim() : '';
 
-            sentResult = true;
+            const summary = element.querySelector(
+                "summary span.color-fg-default"
+            );
+
+            const activityText = summary
+                ? summary.textContent.replace(/\s+/g, " ").trim()
+                : "";
+
             sendResponse({
                 result: `ContributionActivity-${activityText}`,
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
+
             return;
         }
     }

--- a/Extension Files/assets/js/getGithubIssueListCoordinate.js
+++ b/Extension Files/assets/js/getGithubIssueListCoordinate.js
@@ -26,13 +26,28 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
     const elements = document.elementsFromPoint(msg.relX, msg.relY);
     let sentResult = false;
     for (element of elements) {
-        console.log("looping");
+
         if (element.tagName === 'A' && element.querySelector('div')?.textContent.trim() === 'Open') {
             const numberOpen = element.querySelector('span[aria-hidden="true"]')?.textContent.trim();
             console.log('Number of Open issues:', numberOpen);
             sentResult = true;
             sendResponse({
                 result: `NumIssuesOpen-${numberOpen}`,
+                relX: msg.relX,
+                relY: msg.relY,
+                time: msg.time,
+                tagname: element.tagName,
+                id: element.id,
+                url: msg.url
+            });
+            return;
+        }
+        if (element.tagName === 'A' && element.querySelector('div')?.textContent.trim() === 'Closed') {
+            const numberClosed = element.querySelector('span[aria-hidden="true"]')?.textContent.trim();
+            console.log('Number of Closed issues:', numberClosed);
+            sentResult = true;
+            sendResponse({
+                result: `NumIssuesClosed-${numberClosed}`,
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,

--- a/Extension Files/assets/js/getGithubIssueListCoordinate.js
+++ b/Extension Files/assets/js/getGithubIssueListCoordinate.js
@@ -36,6 +36,24 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
+                id: element.id,
+                url: msg.url
+            });
+            return;
+        }
+        if (element.dataset.component === "Breadcrumbs.Item") {
+            console.log("Project/Organization Name");
+
+            const organization = element.textContent.trim();
+
+            sentResult = true;
+            sendResponse({
+                result: `Organization/ProjectName-${organization}`,
+                relX: msg.relX,
+                relY: msg.relY,
+                time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -47,22 +65,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         ) {
             const type = element.getAttribute("data-hovercard-type");
             // This may need to be changed to include project names
-            if (type === "organization") {
-                console.log("Project/Organization Name");
-
-                const organization = element.textContent.trim();
-
-                sentResult = true;
-                sendResponse({
-                    result: `OrganizationName-${organization}`,
-                    relX: msg.relX,
-                    relY: msg.relY,
-                    time: msg.time,
-                    id: element.id,
-                    url: msg.url
-                });
-                return;
-            } else if (type === 'user') {
+            if (type === 'user') {
                 console.log('user link')
                 const user = element.innerHTML;
                 sentResult = true;
@@ -71,6 +74,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: element.id,
                     url: msg.url
                 });
@@ -90,6 +94,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -108,6 +113,8 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
+                    id: element.id,
                     url: msg.url
                 });
                 return;
@@ -129,6 +136,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -144,6 +152,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -159,6 +168,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });

--- a/Extension Files/assets/js/getGithubPRListCoordinate.js
+++ b/Extension Files/assets/js/getGithubPRListCoordinate.js
@@ -58,72 +58,23 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 return;
             }
 
-            // Organization (legacy org link)
-            if (element.classList && element.classList.contains('url') && element.classList.contains('fn') && element.tagName === 'A') {
-                const attr = element.getAttribute('data-hovercard-type');
-                if (attr === 'organization') {
-                    const organization = element.textContent.trim();
-                    sendResponse({
-                        result: `Organization - ${organization}`,
-                        relX: relX,
-                        relY: relY,
-                        time: msg.time,
-                        id: element.id || null,
-                        url: msg.url || location.href
-                    });
-                    return;
-                }
-            }
+            // Organization/Project Link
+            if (element.dataset.component === "Breadcrumbs.Item") {
+                console.log("Project/Organization Name");
 
-            // ProjectName
-            if (element.tagName === 'A') {
-                const projNode = element.closest && element.closest('strong[itemprop="name"]');
-                if (projNode) {
-                    const projectName = element.textContent.trim();
-                    sendResponse({
-                        result: `ProjectName - ${projectName}`,
-                        relX: relX,
-                        relY: relY,
-                        time: msg.time,
-                        id: element.id || null,
-                        url: msg.url || location.href
-                    });
-                    return;
-                }
-            }
+                const organization = element.textContent.trim();
 
-            // NumOfStarred
-            if (element.tagName === 'A') {
-                const starCounter = element.querySelector && element.querySelector('#repo-stars-counter-star, .js-social-count, .Counter.js-social-count');
-                if (starCounter) {
-                    const numberStarred = starCounter.textContent.trim();
-                    sendResponse({
-                        result: `NumOfStarred-${numberStarred}`,
-                        relX: relX,
-                        relY: relY,
-                        time: msg.time,
-                        id: starCounter.id || element.id || null,
-                        url: msg.url || location.href
-                    });
-                    return;
-                }
-            }
-
-            // NumOfForked
-            if (element.tagName === 'A') {
-                const forkCounter = element.querySelector && element.querySelector('#repo-network-counter, .Counter, .Counter.js-social-count');
-                if (forkCounter && (forkCounter.id === 'repo-network-counter' || forkCounter.classList.contains('Counter') || forkCounter.classList.contains('js-social-count'))) {
-                    const numberForked = forkCounter.textContent.trim();
-                    sendResponse({
-                        result: `NumOfForked-${numberForked}`,
-                        relX: relX,
-                        relY: relY,
-                        time: msg.time,
-                        id: forkCounter.id || element.id || null,
-                        url: msg.url || location.href
-                    });
-                    return;
-                }
+                sentResult = true;
+                sendResponse({
+                    result: `Organization/ProjectName-${organization}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    tagname: element.tagName,
+                    id: element.id,
+                    url: msg.url
+                });
+                return;
             }
 
             // Username
@@ -176,44 +127,6 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                         relX: relX,
                         relY: relY,
                         time: msg.time,
-                        url: msg.url || location.href
-                    });
-                    return;
-                }
-            }
-
-            // PR status: review required / approvals / changes requested
-            if (element.tagName === 'A') {
-                const aria = (element.getAttribute('aria-label') || '').toLowerCase();
-                if (aria.includes('review required')) {
-                    sendResponse({
-                        result: `PRStatus-Review Required`,
-                        relX: relX,
-                        relY: relY,
-                        time: msg.time,
-                        id: element.id || null,
-                        url: msg.url || location.href
-                    });
-                    return;
-                }
-                if (aria.includes('review approval') || aria.includes('review approvals') || /\d+\s+review\s+approvals?/.test(aria)) {
-                    sendResponse({
-                        result: `PRStatus-Approval`,
-                        relX: relX,
-                        relY: relY,
-                        time: msg.time,
-                        id: element.id || null,
-                        url: msg.url || location.href
-                    });
-                    return;
-                }
-                if (aria.includes('requesting changes') || aria.includes('changes requested') || aria.includes('request changes')) {
-                    sendResponse({
-                        result: `PRStatus-Changes Requested`,
-                        relX: relX,
-                        relY: relY,
-                        time: msg.time,
-                        id: element.id || null,
                         url: msg.url || location.href
                     });
                     return;
@@ -277,8 +190,6 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
  * - Num PR Open/Closed
  * - Project name
  * - Organization name
- * - Number of forked
- * - Number of starred
  * - Number of comments on PR
  * - Username (opened PR)
  * - PR Title

--- a/Extension Files/assets/js/getGithubPRListCoordinate.js
+++ b/Extension Files/assets/js/getGithubPRListCoordinate.js
@@ -38,6 +38,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: relX,
                     relY: relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: element.id || null,
                     url: msg.url || location.href
                 });
@@ -52,6 +53,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: relX,
                     relY: relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: element.id || null,
                     url: msg.url || location.href
                 });
@@ -88,6 +90,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                             relX: relX,
                             relY: relY,
                             time: msg.time,
+                            tagname: element.tagName,
                             id: element.id || null,
                             url: msg.url || location.href
                         });
@@ -109,6 +112,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                         relX: relX,
                         relY: relY,
                         time: msg.time,
+                        tagname: element.tagName,
                         id: element.id || null,
                         url: msg.url || location.href
                     };
@@ -127,6 +131,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                         relX: relX,
                         relY: relY,
                         time: msg.time,
+                        tagname: element.tagName,
                         url: msg.url || location.href
                     });
                     return;
@@ -142,6 +147,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: relX,
                     relY: relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: element.id || null,
                     url: msg.url || location.href
                 });
@@ -156,6 +162,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: relX,
                     relY: relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: element.id || null,
                     url: msg.url || location.href
                 });

--- a/Extension Files/assets/js/getGithubPRListCoordinate.js
+++ b/Extension Files/assets/js/getGithubPRListCoordinate.js
@@ -31,7 +31,8 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
             if (!element) continue;
 
             // NumPROpen
-            if (element.classList && element.classList.contains('btn-link') && element.innerHTML && element.innerHTML.includes('Open') && element.tagName === 'A') {
+            if (element.classList && element.classList.contains("btn-link") && element.innerHTML && element.innerHTML.includes('Open') && element.tagName === 'A') {
+                console.log("NumPROpen")
                 const numberOpen = element.textContent.trim();
                 sendResponse({
                     result: `NumPROpen-${numberOpen}`,
@@ -47,6 +48,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
 
             // NumPRClosed
             if (element.classList && element.classList.contains('btn-link') && element.innerHTML && element.innerHTML.includes('Closed') && element.tagName === 'A') {
+                console.log("NumPRClosed")
                 const numClosed = element.textContent.trim();
                 sendResponse({
                     result: `NumPRClosed-${numClosed}`,
@@ -83,6 +85,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
             if (element.tagName === 'A') {
                 const hoverType = element.getAttribute && element.getAttribute('data-hovercard-type');
                 if (hoverType === 'user') {
+                    console.log("Username")
                     const username = element.textContent.trim();
                     if (username) {
                         sendResponse({
@@ -103,6 +106,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
             if (element.tagName === 'A') {
                 const hover = element.getAttribute && element.getAttribute('data-hovercard-type');
                 if (hover === 'pull_request') {
+                    console.log("PullReqest link")
                     const title = element.textContent.trim();
                     const href = element.getAttribute('href') || '';
                     const m = href.match(/\/pull\/(\d+)(?:\/|$)/);
@@ -125,6 +129,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
             if (element.tagName === 'A') {
                 const ariaAttr = element.getAttribute && element.getAttribute('aria-label');
                 if (ariaAttr && ariaAttr.toLowerCase().includes('comment')) {
+                    console.log("NumOfComments")
                     const numberOfComments = ariaAttr.match(/\d+/)?.[0] || ariaAttr;
                     sendResponse({
                         result: `NumOfComments-${numberOfComments}`,
@@ -140,6 +145,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
 
             // Time opened (relative-time element)
             if (element.tagName === 'RELATIVE-TIME') {
+                console.log("Time opened (relative-time element)")
                 const opened = element.innerHTML;
                 const timestamp = (element.getAttribute && element.getAttribute('title')) || null;
                 sendResponse({
@@ -156,6 +162,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
 
             // Task progress count
             if (element.tagName === 'TRACKED-ISSUES-PROGRESS') {
+                console.log("Task progress count")
                 const taskProgress = element.dataset.total;
                 sendResponse({
                     result: `TaskCompletion-${taskProgress}`,

--- a/Extension Files/assets/js/getGithubPullRequestCoordinate.js
+++ b/Extension Files/assets/js/getGithubPullRequestCoordinate.js
@@ -48,6 +48,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -79,6 +80,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: filesTab.id,
                     url: msg.url
                 });
@@ -104,6 +106,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: checksTab.id,
                     url: msg.url
                 });
@@ -129,6 +132,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: commitsTab.id,
                     url: msg.url
                 });
@@ -154,6 +158,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: conversationTab.id,
                     url: msg.url
                 });
@@ -170,6 +175,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -187,6 +193,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: diffCell.id,
                     url: msg.url
                 });
@@ -200,6 +207,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: diffCell.id,
                     url: msg.url
                 });
@@ -213,6 +221,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: diffCell.id,
                     url: msg.url
                 });
@@ -231,6 +240,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -246,6 +256,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -263,6 +274,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -277,6 +289,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -291,6 +304,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -318,6 +332,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -330,6 +345,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -344,6 +360,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -357,6 +374,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -373,6 +391,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -389,6 +408,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -405,6 +425,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
+                tagname: element.tagName,
                 id: element.id,
                 url: msg.url
             });
@@ -421,6 +442,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: element.id,
                     url: msg.url
                 });
@@ -437,6 +459,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: element.id,
                     url: msg.url
                 });
@@ -452,6 +475,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: element.id,
                     url: msg.url
                 });
@@ -467,6 +491,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: element.id,
                     url: msg.url
                 });
@@ -482,6 +507,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
+                    tagname: element.tagName,
                     id: element.id,
                     url: msg.url
                 });

--- a/Extension Files/assets/js/getGithubPullRequestCoordinate.js
+++ b/Extension Files/assets/js/getGithubPullRequestCoordinate.js
@@ -63,107 +63,110 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         // }
 
         // Number of files changed
-        if (element.attributes.getNamedItem('href')?.value.includes("/files") && element.classList.contains('tabnav-tab')) {
-            console.log('# of files changed');
-            const filesCounter = element.querySelector('#files_tab_counter');
-            const filesCount = filesCounter ? filesCounter.innerHTML.trim() : 'Unknown';
-            sentResult = true;
-            sendResponse({
-                result: `NumOfFilesChanged-${filesCount}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Number of checks
-        if (element.attributes.getNamedItem('href')?.value.includes("/checks") && element.classList.contains('tabnav-tab')) {
-            console.log('# Checks');
-            const checksCounter = element.querySelector('#checks_tab_counter');
-            const checksCount = checksCounter ? checksCounter.innerHTML.trim() : 'Unknown';
-            sentResult = true;
-            sendResponse({
-                result: `NumOfChecks-${checksCount}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Number of commits
-        if (element.attributes.getNamedItem('href')?.value.includes("/commits") && element.classList.contains('tabnav-tab')) {
-            console.log('# Commits');
-            const commitCounter = element.querySelector('#commits_tab_counter');
-            const commitCount = commitCounter ? commitCounter.innerHTML.trim() : 'Unknown';
-            sentResult = true;
-            sendResponse({
-                result: `NumOfCommits-${commitCount}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Number of conversations
-        if (element.attributes.getNamedItem('href')?.value.includes("/pull/") && element.classList.contains('tabnav-tab') &&
-            element.querySelector('#conversation_tab_counter')) {
-            console.log('# Conversations');
-            const conversationCounter = element.querySelector('#conversation_tab_counter');
-            const conversationCount = conversationCounter ? conversationCounter.innerHTML.trim() : 'Unknown';
-            sentResult = true;
-            sendResponse({
-                result: `NumOfConversationComments-${conversationCount}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        // Number of total diffs
-        if (element.classList.contains('diffstat')) {
-            if (element.id === 'diffstat') {
-                console.log('Number of total diffs');
-                const diffAdd = element.querySelector(".color-fg-success");
-                const diffSub = element.querySelector(".color-fg-danger");
-                sentResult = true;
+        if (element.closest('a[href*="/changes"][role="tab"]')) {
+            const filesTab = element.closest('a[href*="/changes"][role="tab"]');
+            const counter = filesTab.querySelector(
+                '[data-component="CounterLabel"]'
+            );
+
+            if (counter) {
+                const filesCount = counter.textContent.trim();
+
+                console.log(`# Files Changed: ${filesCount}`);
+
                 sendResponse({
-                    result: `TotalDiffs- ${diffAdd}, ${diffSub}`,
+                    result: `NumOfFilesChanged-${filesCount}`,
                     relX: msg.relX,
                     relY: msg.relY,
                     time: msg.time,
-                    id: element.id,
+                    id: filesTab.id,
                     url: msg.url
                 });
+
                 return;
             }
-            // Number of file diffs (deprecated)
-            // if (element.classList.contains('tooltipped')) {
-            //   console.log('Number of file diffs');
-            //   const numChanges = element.attributes.getNamedItem('aria-label').value;
-            //   sentResult = true;
-            //   sendResponse({ result: `NumOfFileDiffs-${numChanges.trim()}`, relX: msg.relX, relY: msg.relY, time: msg.time, id: element.id, url: msg.url });
-            //   return;
-            // }
         }
-        // Deleted line of code
-        if (element.tagName === 'TD' && element.classList.contains('blob-code-deletion')) {
-            console.log('Deleted Line of Code');
-            let lineNumber = 0;
-            const lineNumberCell = element.previousElementSibling;
-            if (lineNumberCell && lineNumberCell.hasAttribute('data-line-number')) {
-                lineNumber = lineNumberCell.getAttribute('data-line-number');
+
+        // Number of checks
+        if (element.closest('a[href*="/checks"][role="tab"]')) {
+            const checksTab = element.closest('a[href*="/checks"][role="tab"]');
+            const counter = checksTab.querySelector(
+                '[data-component="CounterLabel"]'
+            );
+
+            if (counter) {
+                const checksCount = counter.textContent.trim();
+
+                console.log(`# Checks: ${checksCount}`);
+
+                sendResponse({
+                    result: `NumOfChecks-${checksCount}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: checksTab.id,
+                    url: msg.url
+                });
+
+                return;
             }
+        }
+
+        // Number of commits
+        if (element.closest('a[href*="/commits"][role="tab"]')) {
+            const commitsTab = element.closest('a[href*="/commits"][role="tab"]');
+            const counter = commitsTab.querySelector(
+                '[data-component="CounterLabel"]'
+            );
+
+            if (counter) {
+                const commitCount = counter.textContent.trim();
+
+                console.log(`# Commits: ${commitCount}`);
+
+                sendResponse({
+                    result: `NumOfCommits-${commitCount}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: commitsTab.id,
+                    url: msg.url
+                });
+
+                return;
+            }
+        }
+
+        // Number of conversation comments
+        if (element.closest('a[href*="/pull/"][role="tab"]')) {
+            const conversationTab = element.closest('a[href*="/pull/"][role="tab"]');
+            const counter = conversationTab.querySelector(
+                '[data-component="CounterLabel"]'
+            );
+
+            if (counter) {
+                const conversationCount = counter.textContent.trim();
+
+                console.log(`# Conversations: ${conversationCount}`);
+
+                sendResponse({
+                    result: `NumOfConversationComments-${conversationCount}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: conversationTab.id,
+                    url: msg.url
+                });
+
+                return;
+            }
+        }
+        // Number of total diffs
+        if (element.closest('.PullRequestHeader-module__diffStatesWrapper__l3nLn')) {
+            const summary = element.closest('.PullRequestHeader-module__diffStatesWrapper__l3nLn').querySelector('.sr-only').textContent.trim();
             sentResult = true;
             sendResponse({
-                result: `DeletedLOC-${lineNumber}`,
+                result: `TotalDiffs-${summary}`,
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
@@ -173,17 +176,58 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
             return;
         }
         // Added line of code
-        if (element.tagName === 'TD' && element.classList.contains('blob-code-addition')) {
-            console.log('Added Line of Code');
-            let lineNumber = 0;
-            const lineNumberCell = element.previousElementSibling;
-            if (lineNumberCell && lineNumberCell.hasAttribute('data-line-number')) {
-                lineNumber = lineNumberCell.getAttribute('data-line-number');
-            }
+        if (element.closest('td.diff-text-cell[data-line-number]')) {
+            const diffCell = element.closest('td.diff-text-cell[data-line-number]');
+            const lineNumber = diffCell.getAttribute('data-line-number') || 'Unknown';
+            if (diffCell.querySelector('code.addition')) {
+                console.log(`Added Line of Code: ${lineNumber}`);
 
+                sendResponse({
+                    result: `AddedLOC-${lineNumber}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: diffCell.id,
+                    url: msg.url
+                });
+
+                return;
+            } else if (diffCell.querySelector('code.deletion')) {
+                console.log(`Deleted Line of Code: ${lineNumber}`);
+
+                sendResponse({
+                    result: `DeletedLOC-${lineNumber}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: diffCell.id,
+                    url: msg.url
+                });
+
+                return;
+            } else {
+                console.log(`Context Line of Code: ${lineNumber}`);
+
+                sendResponse({
+                    result: `ContextLOC-${lineNumber}`,
+                    relX: msg.relX,
+                    relY: msg.relY,
+                    time: msg.time,
+                    id: diffCell.id,
+                    url: msg.url
+                });
+
+                return;
+            }
+        }
+        // File Name
+        if (element.closest('a[href*="#diff-"]')) {
+            console.log("Filename")
+            // const fileName = element.attributes.getNamedItem('title').value;
+            const fileName = element.innerHTML;
             sentResult = true;
             sendResponse({
-                result: `AddedLOC-${lineNumber}`,
+                result: `File-${fileName.trim()}`,
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
@@ -192,56 +236,20 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
             });
             return;
         }
-        // Unchanged line of code
-        if (element.tagName === 'TD' && element.classList.contains('blob-code-context')) {
-            console.log('Unchanged Line of Code');
-            let lineNumber = 0;
-            const lineNumberCell = element.previousElementSibling;
-            if (lineNumberCell && lineNumberCell.hasAttribute('data-line-number')) {
-                lineNumber = lineNumberCell.getAttribute('data-line-number');
-            }
-            sendResponse({
-                result: `UnchangedLOC-${lineNumber}`,
-                relX: msg.relX,
-                relY: msg.relY,
-                time: msg.time,
-                id: element.id,
-                url: msg.url
-            });
-            return;
-        }
-        if (element.tagName === 'a' && element.attributes.getNamedItem('href')) {
-            // File name
-            if (element.attributes.getNamedItem('href').value.includes("#diff-") && element.classList.contains('text-mono')) {
-                console.log("Filename")
-                // const fileName = element.attributes.getNamedItem('title').value;
-                const fileName = element.innerHTML;
-                sentResult = true;
-                sendResponse({
-                    result: `File-${fileName.trim()}`,
-                    relX: msg.relX,
-                    relY: msg.relY,
-                    time: msg.time,
-                    id: element.id,
-                    url: msg.url
-                });
-                return;
-            }
+        if (element.closest('a[href*="/changes"]')) {
             // Commit name
-            if (element.attributes.getNamedItem('href').value.includes("commits/")) {
-                console.log("Commit name");
-                const commitTitle = element.innerHTML;
-                sentResult = true;
-                sendResponse({
-                    result: `CommitName-${commitTitle.trim()}`,
-                    relX: msg.relX,
-                    relY: msg.relY,
-                    time: msg.time,
-                    id: element.id,
-                    url: msg.url
-                });
-                return;
-            }
+            console.log("Commit name");
+            const commitTitle = element.innerHTML;
+            sentResult = true;
+            sendResponse({
+                result: `CommitName-${commitTitle.trim()}`,
+                relX: msg.relX,
+                relY: msg.relY,
+                time: msg.time,
+                id: element.id,
+                url: msg.url
+            });
+            return;
         }
         if (element.attributes.getNamedItem('data-hovercard-type') && element.attributes.getNamedItem('data-hovercard-type').value === 'user') {
             console.log('username')
@@ -259,11 +267,13 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 url: msg.url
             });
         }
-        if (element.classList.contains('js-issue-title')) {
+        if (element.closest('[data-component="PH_Title"]')) {
+            const titleSpan = element.closest('[data-component="PH_Title"]')?.querySelector('span');
+            const title = titleSpan?.textContent.trim();
             console.log('PR Title');
             sentResult = true;
             sendResponse({
-                result: `PRTitle-${element.innerHTML.trim()}`,
+                result: `PRTitle-${title}`,
                 relX: msg.relX,
                 relY: msg.relY,
                 time: msg.time,
@@ -328,7 +338,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
         if (element.classList.contains('IssueLabel')) {
             console.log("Issue Label");
             sentResult = true;
-            const labelName = element.firstChild.nextSibling ? element.firstChild.nextSibling.innerHTML : '';
+            const labelName = element.textContent.trim();
             sendResponse({
                 result: `IssueLabel-${labelName}`,
                 relX: msg.relX,
@@ -417,6 +427,7 @@ chrome.runtime.onMessage.addListener(function (msg, sender, sendResponse) {
                 return;
             }
             // Avatar in Comment Header
+            // Not entirely sure what this is referring to, may need to be updated
             if (element.classList.contains('rounded-1')) {
                 console.log('User avatar - Comment header');
                 sentResult = true;

--- a/Extension Files/manifest.json
+++ b/Extension Files/manifest.json
@@ -66,7 +66,7 @@
     },
     {
       "matches": [
-        "https://github.com/*/"
+        "https://github.com/*"
       ],
       "js": [
         "/assets/js/getGithubDevProfileCoordinate.js"


### PR DESCRIPTION
Originally, this branch was made to clean up undefined XML variables in the output generated by content scripts (namely the <word> and <line> variables). However, it's been decided that it is best to leave those be for now. Instead, this PR deals with cleaning up the GitHub content scripts in order to answer the concerns described in #21. Most of the GitHub content scripts had outdated AOI descriptors, causing them to fail to detect certain AOIs. This has been addressed by updating the descriptors they use for detection.

Additionally, the tagname variable has been added to the GitHub content scripts and is now standard across all provided content scripts.

Changes:
* Updated GitHub Content Scripts to address failing detections as raised in #21 
* Updated BugZilla Content Script to address failing detections
* Added tagname variable to GitHub content scripts that lacked it