### PR TITLE
Fix remove redundant manfiest perms

### DIFF
--- a/Extension Files/manifest.json
+++ b/Extension Files/manifest.json
@@ -30,11 +30,5 @@
     "*://bugzilla.mozilla.org/*",
     "*://bugzilla.kernel.org/*",
     "*://bz.apache.org/*"
-  ],
-  "externally_connectable": {
-    "matches": [
-      "*://*.stackoverflow.com/**",
-      "https://stackoverflow.com/*"
-    ]
-  }
+  ]
 }

--- a/Extension Files/manifest.json
+++ b/Extension Files/manifest.json
@@ -3,76 +3,6 @@
   "name": "iTrace-Chrome Plugin",
   "description": "Plugin which allows for tracking eyegaze data on webpages in Chrome.",
   "version": "0.0.1",
-  "content_scripts": [
-    {
-      "matches": [
-        "https://stackoverflow.com/questions*"
-      ],
-      "js": [
-        "/assets/js/getSOCoordinate.js"
-      ]
-    },
-    {
-      "matches": [
-        "*://bugzilla-dev.allizom.org/*",
-        "*://bugs.eclipse.org/*",
-        "*://bugzilla.mozilla.org/*",
-        "*://bugzilla.kernel.org/*",
-        "*://bz.apache.org/*"
-      ],
-      "js": [
-        "/assets/js/getBZCoordinate.js"
-      ]
-    },
-    {
-      "matches": [
-        "https://stackoverflow.com/search*"
-      ],
-      "js": [
-        "/assets/js/getSearchCoordinate.js"
-      ]
-    },
-    {
-      "matches": [
-        "https://*.google.com/*"
-      ],
-      "js": [
-        "/assets/js/getGoogleCoordinate.js"
-      ]
-    },
-    {
-      "matches": [
-        "https://github.com/*/*/issues*"
-      ],
-      "js": [
-        "/assets/js/getGithubIssueListCoordinate.js"
-      ]
-    },
-    {
-      "matches": [
-        "https://github.com/*/*/pulls*"
-      ],
-      "js": [
-        "/assets/js/getGithubPRListCoordinate.js"
-      ]
-    },
-    {
-      "matches": [
-        "https://github.com/*/pull/*"
-      ],
-      "js": [
-        "/assets/js/getGithubPullRequestCoordinate.js"
-      ]
-    },
-    {
-      "matches": [
-        "https://github.com/*"
-      ],
-      "js": [
-        "/assets/js/getGithubDevProfileCoordinate.js"
-      ]
-    }
-  ],
   "background": {
     "service_worker": "assets/js/background.js"
   },
@@ -89,7 +19,6 @@
     "storage",
     "scripting",
     "tabs",
-    "activeTab",
     "downloads"
   ],
   "host_permissions": [


### PR DESCRIPTION
This PR removes redundant and obsolete components of the manifest file in order to prepare the extension to be placed on the Chrome Web Store.

Changes:
* content_script section of the manifest file has been removed; This section is no longer necessary, as the service worker (background.js) now handles all injections.

* permission "activeTab" removed; This permission is no longer necessary as the extension now relies on the host_permissions section of the manifest file to inject. The host_permissions section is preferred as it works better with the current method of injecting content_scripts in the service worker.

* externally_connectable: This section of the manifest file was removed as no use of its permission can be found in the code. It is likely a hold over from a different study that required it, but has no use in master's version. Since we need the manifest file as clean as possible, it will be removed.